### PR TITLE
Remove null origin hack from demos

### DIFF
--- a/examples/electron-javascript-npm/index.html
+++ b/examples/electron-javascript-npm/index.html
@@ -3,10 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
-    <meta http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://*.grammarly.com; style-src 'self' 'unsafe-inline'; img-src data: https://*.grammarly.com; connect-src https://*.grammarly.com https://*.grammarly.io wss://*.grammarly.com" />
-    <meta http-equiv="X-Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://js.grammarly.com; style-src 'unsafe-inline'; img-src data: https://*.grammarly.com; connect-src * 'unsafe-inline'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://*.grammarly.com; style-src 'self' 'unsafe-inline'; img-src data: https://*.grammarly.com; connect-src https://*.grammarly.com https://*.grammarly.io wss://*.grammarly.com" />
+    <meta http-equiv="X-Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://js.grammarly.com; style-src 'unsafe-inline'; img-src data: https://*.grammarly.com; connect-src * 'unsafe-inline'">
     <title>Grammarly Electron Demo</title>
   </head>
   <style>

--- a/examples/electron-javascript-npm/index.html
+++ b/examples/electron-javascript-npm/index.html
@@ -3,8 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://js.grammarly.com; style-src 'unsafe-inline'; connect-src * 'unsafe-inline'">
-    <meta http-equiv="X-Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://js.grammarly.com; style-src 'unsafe-inline'; connect-src * 'unsafe-inline'">
+    <meta http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://*.grammarly.com; style-src 'self' 'unsafe-inline'; img-src data: https://*.grammarly.com; connect-src https://*.grammarly.com https://*.grammarly.io wss://*.grammarly.com" />
+    <meta http-equiv="X-Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://js.grammarly.com; style-src 'unsafe-inline'; img-src data: https://*.grammarly.com; connect-src * 'unsafe-inline'">
     <title>Grammarly Electron Demo</title>
   </head>
   <style>

--- a/examples/electron-javascript-npm/main.js
+++ b/examples/electron-javascript-npm/main.js
@@ -16,18 +16,6 @@ const createWindow = () => {
 };
 
 app.setAsDefaultProtocolClient("example");
-function enableTemporaryGrammarlyOriginWorkaround() {
-  // Modify the origin for all requests to the following urls.
-  const filter = {
-    urls: ["https://*.grammarly.com/*"],
-  };
-
-  session.defaultSession.webRequest.onBeforeSendHeaders(filter, (details, callback) => {
-    details.requestHeaders.Origin = "null";
-    // eslint-disable-next-line node/no-callback-literal
-    callback({ requestHeaders: details.requestHeaders });
-  });
-}
 
 function handleGrammarlyOAuthCallback(win) {
   app.on("open-url", (event, link) => {
@@ -59,7 +47,6 @@ function handleNewWindowLinks(win) {
 app.whenReady().then(() => {
   const win = createWindow();
 
-  enableTemporaryGrammarlyOriginWorkaround()
   handleGrammarlyOAuthCallback(win)
   handleNewWindowLinks(win)
 });

--- a/examples/electron-react/main.js
+++ b/examples/electron-react/main.js
@@ -16,18 +16,6 @@ const createWindow = () => {
 };
 
 app.setAsDefaultProtocolClient("example");
-function enableTemporaryGrammarlyOriginWorkaround() {
-  // Modify the origin for all requests to the following urls.
-  const filter = {
-    urls: ["https://*.grammarly.com/*"],
-  };
-
-  session.defaultSession.webRequest.onBeforeSendHeaders(filter, (details, callback) => {
-    details.requestHeaders.Origin = "null";
-    // eslint-disable-next-line node/no-callback-literal
-    callback({ requestHeaders: details.requestHeaders });
-  });
-}
 
 function handleGrammarlyOAuthCallback(win) {
   app.on("open-url", (event, link) => {
@@ -59,7 +47,6 @@ function handleNewWindowLinks(win) {
 app.whenReady().then(() => {
   const win = createWindow();
 
-  enableTemporaryGrammarlyOriginWorkaround()
   handleGrammarlyOAuthCallback(win)
   handleNewWindowLinks(win)
 });

--- a/examples/electron-vue/main.js
+++ b/examples/electron-vue/main.js
@@ -16,18 +16,6 @@ const createWindow = () => {
 };
 
 app.setAsDefaultProtocolClient("example");
-function enableTemporaryGrammarlyOriginWorkaround() {
-  // Modify the origin for all requests to the following urls.
-  const filter = {
-    urls: ["https://*.grammarly.com/*"],
-  };
-
-  session.defaultSession.webRequest.onBeforeSendHeaders(filter, (details, callback) => {
-    details.requestHeaders.Origin = "null";
-    // eslint-disable-next-line node/no-callback-literal
-    callback({ requestHeaders: details.requestHeaders });
-  });
-}
 
 function handleGrammarlyOAuthCallback(win) {
   app.on("open-url", (event, link) => {
@@ -59,7 +47,6 @@ function handleNewWindowLinks(win) {
 app.whenReady().then(() => {
   const win = createWindow();
 
-  enableTemporaryGrammarlyOriginWorkaround()
   handleGrammarlyOAuthCallback(win)
   handleNewWindowLinks(win)
 });

--- a/examples/electron/index.html
+++ b/examples/electron/index.html
@@ -3,8 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://js.grammarly.com; style-src 'unsafe-inline'; connect-src * 'unsafe-inline'">
-    <meta http-equiv="X-Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://js.grammarly.com; style-src 'unsafe-inline'; connect-src * 'unsafe-inline'">
+    <meta http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://*.grammarly.com; style-src 'self' 'unsafe-inline'; img-src data: https://*.grammarly.com; connect-src https://*.grammarly.com https://*.grammarly.io wss://*.grammarly.com" />
+    <meta http-equiv="X-Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://js.grammarly.com; style-src 'unsafe-inline'; img-src data: https://*.grammarly.com; connect-src * 'unsafe-inline'">
     <title>Grammarly Electron Demo</title>
   </head>
   <style>
@@ -73,7 +74,7 @@ It can even help when you wanna refine ur slang or formality level. That's espec
       </p>
     </div>
 
-    <script src="https://unpkg.com/@grammarly/editor-sdk?clientId=YOUR_CLIENT_ID"></script>
+    <script src="https://unpkg.com/@grammarly/editor-sdk?clientId=client_HnzieFTn5eQba7kebwpBsC"></script>
     <script>
       Grammarly.init().then((grammarly) => {
         grammarly.withElement(document.querySelector("div[contenteditable]"), {

--- a/examples/electron/index.html
+++ b/examples/electron/index.html
@@ -74,7 +74,7 @@ It can even help when you wanna refine ur slang or formality level. That's espec
       </p>
     </div>
 
-    <script src="https://unpkg.com/@grammarly/editor-sdk?clientId=client_HnzieFTn5eQba7kebwpBsC"></script>
+    <script src="https://unpkg.com/@grammarly/editor-sdk?clientId=YOUR_CLIENT_ID"></script>
     <script>
       Grammarly.init().then((grammarly) => {
         grammarly.withElement(document.querySelector("div[contenteditable]"), {

--- a/examples/electron/index.html
+++ b/examples/electron/index.html
@@ -3,8 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
-    <meta http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://*.grammarly.com; style-src 'self' 'unsafe-inline'; img-src data: https://*.grammarly.com; connect-src https://*.grammarly.com https://*.grammarly.io wss://*.grammarly.com" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://*.grammarly.com; style-src 'self' 'unsafe-inline'; img-src data: https://*.grammarly.com; connect-src https://*.grammarly.com https://*.grammarly.io wss://*.grammarly.com" />
     <meta http-equiv="X-Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://js.grammarly.com; style-src 'unsafe-inline'; img-src data: https://*.grammarly.com; connect-src * 'unsafe-inline'">
     <title>Grammarly Electron Demo</title>
   </head>

--- a/examples/electron/main.js
+++ b/examples/electron/main.js
@@ -16,18 +16,6 @@ const createWindow = () => {
 };
 
 app.setAsDefaultProtocolClient("example");
-function enableTemporaryGrammarlyOriginWorkaround() {
-  // Modify the origin for all requests to the following urls.
-  const filter = {
-    urls: ["https://*.grammarly.com/*"],
-  };
-
-  session.defaultSession.webRequest.onBeforeSendHeaders(filter, (details, callback) => {
-    details.requestHeaders.Origin = "null";
-    // eslint-disable-next-line node/no-callback-literal
-    callback({ requestHeaders: details.requestHeaders });
-  });
-}
 
 function handleGrammarlyOAuthCallback(win) {
   app.on("open-url", (event, link) => {
@@ -59,7 +47,6 @@ function handleNewWindowLinks(win) {
 app.whenReady().then(() => {
   const win = createWindow();
 
-  enableTemporaryGrammarlyOriginWorkaround()
   handleGrammarlyOAuthCallback(win)
   handleNewWindowLinks(win)
 });


### PR DESCRIPTION
- Remove the code that sets the origin header to null (this was a temporary workaround that is no longer necessary)
- Fix Content Security Policy errors