### PR TITLE
Remove SDK version from script tag

### DIFF
--- a/examples/editor-sdk/public/index.html
+++ b/examples/editor-sdk/public/index.html
@@ -73,6 +73,6 @@ It can even help when you wanna refine ur slang or formality level. That's espec
       </p>
     </div>
 
-    <script src="https://unpkg.com/@grammarly/editor-sdk@1.6?clientId=5c891c34-55b1-4504-b1a2-5215d35757ba"></script>
+    <script src="https://unpkg.com/@grammarly/editor-sdk?clientId=5c891c34-55b1-4504-b1a2-5215d35757ba"></script>
   </body>
 </html>


### PR DESCRIPTION
@wachunga I tried to turn on autocomplete in a CodeSandbox that uses the repo, and it didn't work. Took me a minute to figure out this was using an older version of the SDK. Is there a benefit to specifying the version in these examples instead of pulling the latest?