### PR TITLE
Add configurator to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,10 @@ The Text Editor SDK provides writing assistance to your end users across several
 - **Engagement** - Chooses the most compelling words and uses varied, engaging sentence structure.
 - **Delivery** - Helps end users find the right tone, eliminates hedging language (to sound more confident), finesses phrases to have more tact and empathy for readers, and supports respectful and current language practices.
 
+### Trying the SDK
 [Try the demo](https://developer.grammarly.com/docs/demo) to get a feel for the experience your users will have when you integrate Grammarly into your app.
+
+You can also [try the configurator](https://developer.grammarly.com/configure) to test different color, theme, and feature combinations. When you're happy with your configuration, copy the code blocks on the page directly into your project, or click the Share button to generate a URL that you can share with your friends and teammates.
 
 ### Installing the SDK
 Add our real-time writing assistance to your app with just a few lines of code.


### PR DESCRIPTION
Extend the line on trying the SDK to its own section and add information on the Configurator to that new section.

<img width="1106" alt="image" src="https://user-images.githubusercontent.com/5179225/205672234-f240d5d7-cb22-4b7d-9a73-e42c5e2fe897.png">
