### PR TITLE
Refactor document dialect example

### DIFF
--- a/examples/editor-sdk-document-dialect/public/dialects/american-english.html
+++ b/examples/editor-sdk-document-dialect/public/dialects/american-english.html
@@ -33,7 +33,7 @@
       preferences.
     </p>
     <p>
-      <a href="/index.html">Click here to return to the index.</a>
+      <a href="/index.html">Return to the index.</a>
     </p>
 
     <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.3?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>

--- a/examples/editor-sdk-document-dialect/public/dialects/american-english.html
+++ b/examples/editor-sdk-document-dialect/public/dialects/american-english.html
@@ -16,9 +16,9 @@
       <code>"american"</code> dialect setting.
     </p>
     <p>
-      <strong>Try the Grammary Editor Plugin in the text area below!</strong>
+      <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
     </p>
-    <grammarly-editor-plugin config.documentDialect="american">
+    <grammarly-editor-plugin config.activation="immediate" config.documentDialect="american">
       <div contenteditable="true">
         <p>
           I like the color green. But not the colour blue so much.

--- a/examples/editor-sdk-document-dialect/public/dialects/american-english.html
+++ b/examples/editor-sdk-document-dialect/public/dialects/american-english.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <link rel="stylesheet" href="/style.css" />
+    <title>Demo App</title>
+  </head>
+  <body>
+    <h2>Document Dialect (American English)</h2>
+    <p>
+      The Grammarly Editor Plugin on this page is set to use the
+      <code>"american"</code> dialect setting.
+    </p>
+    <p>
+      <strong>Try the Grammary Editor Plugin in the text area below!</strong>
+    </p>
+    <grammarly-editor-plugin config.documentDialect="american">
+      <div contenteditable="true">
+        <p>
+          I like the color green. But not the colour blue so much.
+        </p>
+      </div>
+    </grammarly-editor-plugin>
+
+    <p>
+      To view the detected/configured dialect, click the Grammarly button, and
+      then review the dialect value in the "I write in" dropdown list. Note that
+      your users can always override this value to match their own dialect
+      preferences.
+    </p>
+    <p>
+      <a href="/index.html">Click here to return to the index.</a>
+    </p>
+
+    <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.3?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+  </body>
+</html>

--- a/examples/editor-sdk-document-dialect/public/dialects/australian-english.html
+++ b/examples/editor-sdk-document-dialect/public/dialects/australian-english.html
@@ -16,9 +16,9 @@
       <code>"australian"</code> dialect setting.
     </p>
     <p>
-      <strong>Try the Grammary Editor Plugin in the text area below!</strong>
+      <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
     </p>
-    <grammarly-editor-plugin config.documentDialect="australian">
+    <grammarly-editor-plugin config.activation="immediate" config.documentDialect="australian">
       <div contenteditable="true">
         <p>
           I like the color green. But not the colour blue so much.

--- a/examples/editor-sdk-document-dialect/public/dialects/australian-english.html
+++ b/examples/editor-sdk-document-dialect/public/dialects/australian-english.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <link rel="stylesheet" href="/style.css" />
+    <title>Demo App</title>
+  </head>
+  <body>
+    <h2>Document Dialect (Australian English)</h2>
+    <p>
+      The Grammarly Editor Plugin on this page is set to use the
+      <code>"australian"</code> dialect setting.
+    </p>
+    <p>
+      <strong>Try the Grammary Editor Plugin in the text area below!</strong>
+    </p>
+    <grammarly-editor-plugin config.documentDialect="australian">
+      <div contenteditable="true">
+        <p>
+          I like the color green. But not the colour blue so much.
+        </p>
+      </div>
+    </grammarly-editor-plugin>
+
+    <p>
+      To view the detected/configured dialect, click the Grammarly button, and
+      then review the dialect value in the "I write in" dropdown list. Note that
+      your users can always override this value to match their own dialect
+      preferences.
+    </p>
+    <p>
+      <a href="/index.html">Click here to return to the index.</a>
+    </p>
+
+    <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.3?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+  </body>
+</html>

--- a/examples/editor-sdk-document-dialect/public/dialects/british-english.html
+++ b/examples/editor-sdk-document-dialect/public/dialects/british-english.html
@@ -16,9 +16,9 @@
       <code>"british"</code> dialect setting.
     </p>
     <p>
-      <strong>Try the Grammary Editor Plugin in the text area below!</strong>
+      <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
     </p>
-    <grammarly-editor-plugin config.documentDialect="british">
+    <grammarly-editor-plugin config.activation="immediate" config.documentDialect="british">
       <div contenteditable="true">
         <p>
           I like the color green. But not the colour blue so much.

--- a/examples/editor-sdk-document-dialect/public/dialects/british-english.html
+++ b/examples/editor-sdk-document-dialect/public/dialects/british-english.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <link rel="stylesheet" href="/style.css" />
+    <title>Demo App</title>
+  </head>
+  <body>
+    <h2>Document Dialect (British English)</h2>
+    <p>
+      The Grammarly Editor Plugin on this page is set to use the
+      <code>"british"</code> dialect setting.
+    </p>
+    <p>
+      <strong>Try the Grammary Editor Plugin in the text area below!</strong>
+    </p>
+    <grammarly-editor-plugin config.documentDialect="british">
+      <div contenteditable="true">
+        <p>
+          I like the color green. But not the colour blue so much.
+        </p>
+      </div>
+    </grammarly-editor-plugin>
+
+    <p>
+      To view the detected/configured dialect, click the Grammarly button, and
+      then review the dialect value in the "I write in" dropdown list. Note that
+      your users can always override this value to match their own dialect
+      preferences.
+    </p>
+    <p>
+      <a href="/index.html">Click here to return to the index.</a>
+    </p>
+
+    <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.3?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+  </body>
+</html>

--- a/examples/editor-sdk-document-dialect/public/dialects/canadian-english.html
+++ b/examples/editor-sdk-document-dialect/public/dialects/canadian-english.html
@@ -15,7 +15,10 @@
       The Grammarly Editor Plugin on this page is set to use the
       <code>"canadian"</code> dialect setting.
     </p>
-    <grammarly-editor-plugin config.documentDialect="canadian">
+    <p>
+      <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
+    </p>
+    <grammarly-editor-plugin config.activation="immediate" config.documentDialect="canadian">
       <div contenteditable="true">
         <p>
           I like the color green. But not the colour blue so much.

--- a/examples/editor-sdk-document-dialect/public/dialects/canadian-english.html
+++ b/examples/editor-sdk-document-dialect/public/dialects/canadian-english.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <link rel="stylesheet" href="/style.css" />
+    <title>Demo App</title>
+  </head>
+  <body>
+    <h2>Document Dialect (Canadian English)</h2>
+    <p>
+      The Grammarly Editor Plugin on this page is set to use the
+      <code>"canadian"</code> dialect setting.
+    </p>
+    <grammarly-editor-plugin config.documentDialect="canadian">
+      <div contenteditable="true">
+        <p>
+          I like the color green. But not the colour blue so much.
+        </p>
+      </div>
+    </grammarly-editor-plugin>
+
+    <p>
+      To view the detected/configured dialect, click the Grammarly button, and
+      then review the dialect value in the "I write in" dropdown list. Note that
+      your users can always override this value to match their own dialect
+      preferences.
+    </p>
+    <p>
+      <a href="/index.html">Click here to return to the index.</a>
+    </p>
+
+    <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.3?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+  </body>
+</html>

--- a/examples/editor-sdk-document-dialect/public/index.html
+++ b/examples/editor-sdk-document-dialect/public/index.html
@@ -6,41 +6,23 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
+    <link rel="stylesheet" href="/style.css">
     <title>Demo App</title>
-    <style>
-      * {
-        box-sizing: border-box;
-      }
-
-      body {
-        font-family: sans-serif;
-      }
-
-      input,
-      textarea,
-      [contenteditable] {
-        font: inherit;
-        line-height: 1.5;
-        width: 600px;
-        padding: 8px 12px;
-        overflow: auto;
-      }
-
-      label {
-        display: block;
-        margin-bottom: 4px;
-      }
-
-      [contenteditable] {
-        height: 10rem;
-        border: 1px solid;
-        resize: both;
-      }
-    </style>
   </head>
   <body>
-    <h2>Canadian Dialect</h2>
-    <grammarly-editor-plugin config.documentDialect="canadian">
+    <h2>Document Dialect (Auto Browser)</h2>
+    <p>
+      By default, Grammarly sets an appropriate dialect based on your user's
+      browser settings (<code>"auto-browser"</code>).
+    </p>
+    <p>
+      Alternatively, you can configure Grammarly to set an appropriate dialect based on your
+      user's written text (<code>"auto-text"</code>).
+    </p>
+    <p>
+      <strong>Try the Grammary Editor Plugin in the text area below!</strong>
+    </p>
+    <grammarly-editor-plugin config.activation="immediate">
       <div contenteditable="true">
         <p>
           I like the color green. But not the colour blue so much.
@@ -48,14 +30,20 @@
       </div>
     </grammarly-editor-plugin>
 
-    <h2>American Dialect</h2>
-    <grammarly-editor-plugin config.documentDialect="american">
-      <div contenteditable="true">
-        <p>
-          I like the color green. But not the colour blue so much.
-        </p>
-      </div>
-    </grammarly-editor-plugin>
+    <p>
+      To view the detected/configured dialect, click the Grammarly button, and then review the dialect value in the "I write in" dropdown list.
+      Note that your users can always override this value to match their own dialect preferences.
+    </p>
+
+    <p>
+      Explore these other pages to try different dialect configurations:
+      <ul>
+        <li><a href="/dialects/american-english.html">American</a> (<code>"american"</code>)
+        <li><a href="/dialects/british-english.html">British</a> (<code>"british"</code>)
+        <li><a href="/dialects/canadian-english.html">Canadian</a> (<code>"canadian"</code>)
+        <li><a href="/dialects/australian-english.html">Australian</a> (<code>"australian"</code>)
+      </ul>
+    </p>
 
     <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.3?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>

--- a/examples/editor-sdk-document-dialect/public/index.html
+++ b/examples/editor-sdk-document-dialect/public/index.html
@@ -20,7 +20,7 @@
       user's written text (<code>"auto-text"</code>).
     </p>
     <p>
-      <strong>Try the Grammary Editor Plugin in the text area below!</strong>
+      <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
     </p>
     <grammarly-editor-plugin config.activation="immediate">
       <div contenteditable="true">

--- a/examples/editor-sdk-document-dialect/public/style.css
+++ b/examples/editor-sdk-document-dialect/public/style.css
@@ -1,0 +1,34 @@
+<style>
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: sans-serif;
+}
+
+ul li {
+  line-height: 1.5em;
+}
+
+input,
+textarea,
+[contenteditable] {
+  font: inherit;
+  line-height: 1.5;
+  width: 600px;
+  padding: 8px 12px;
+  overflow: auto;
+}
+
+label {
+  display: block;
+  margin-bottom: 4px;
+}
+
+[contenteditable] {
+  height: 10rem;
+  border: 1px solid;
+  resize: both;
+}
+</style>

--- a/examples/editor-sdk-document-dialect/readme.md
+++ b/examples/editor-sdk-document-dialect/readme.md
@@ -10,7 +10,7 @@ You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/
 
 [index.html](./public/index.html) and the other HTML files in this repository contain `<div contenteditable>` elements. These elements are wrapped with the `<grammarly-editor-plugin>` web component so that Grammarly suggestions will be displayed in them. 
 
-HTML attributes on `<grammarly-editor-plugin>` toward the bottom of the file configure the Grammarly Text Editor SDK according to the set English dialect. See [index.html](./public/index.html) for the full code example.
+HTML attributes on `<grammarly-editor-plugin>` toward the bottom of the file configure the Grammarly Text Editor SDK. See [index.html](./public/index.html) for the full code example.
 
 ## Get the code
 

--- a/examples/editor-sdk-document-dialect/readme.md
+++ b/examples/editor-sdk-document-dialect/readme.md
@@ -1,6 +1,6 @@
 # Grammarly Text Editor SDK with documentDialect
 
-This demo shows how to add [documentDialect](https://developer.grammarly.com/docs/api/editor-sdk/editorconfig#documentdialect) to  [Grammarly Text Editor SDK](https://developer.grammarly.com/).
+This demo shows how to add [documentDialect](https://developer.grammarly.com/docs/api/editor-sdk/editorconfig#documentdialect) to the [Grammarly Text Editor SDK](https://developer.grammarly.com/).
 
 ## Try the demo
 
@@ -8,7 +8,9 @@ You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/
 
 ## How it works
 
-[index.html](./public/index.html) contains `<div contenteditable>` elements. These elements are wrapped with the `<grammarly-editor-plugin>` tag so that Grammarly suggestions will be displayed in them. JavaScript code toward the bottom of the file configures the Grammarly Text Editor SDK. See [index.html](./public/index.html) for the full code example.
+[index.html](./public/index.html) and the other HTML files in this repository contain `<div contenteditable>` elements. These elements are wrapped with the `<grammarly-editor-plugin>` web component so that Grammarly suggestions will be displayed in them. 
+
+HTML attributes on `<grammarly-editor-plugin>` toward the bottom of the file configure the Grammarly Text Editor SDK according to the set English dialect. See [index.html](./public/index.html) for the full code example.
 
 ## Get the code
 


### PR DESCRIPTION
At present, the Text Editor SDK honors one configuration for an editor on a page. This MR refactors the document dialect example to include demos for the supported language dialects. The index is set to the default ("auto-browser").

To test, create a codesandbox from https://github.com/AndrewDiMola/grammarly-for-developers/tree/refactor-document-dialect-example/examples/editor-sdk-document-dialect.

(https://codesandbox.io/s/github/andrewdimola/grammarly-for-developers/tree/refactor-document-dialect-example/examples/editor-sdk-document-dialect?file=/public/index.html)