### PR TITLE
Refactor document domain example

### DIFF
--- a/examples/editor-sdk-document-dialect/public/index.html
+++ b/examples/editor-sdk-document-dialect/public/index.html
@@ -12,11 +12,11 @@
   <body>
     <h2>Document Dialect (Auto Browser)</h2>
     <p>
-      By default, Grammarly sets an appropriate English dialect according to your user's
+      By default, Grammarly sets the English dialect according to your user's
       browser settings (<code>"auto-browser"</code>).
     </p>
     <p>
-      Alternatively, you can configure Grammarly to set a dialect according to your
+      Alternatively, you can configure Grammarly to set the dialect according to your
       user's written text (<code>"auto-text"</code>) or the expected English dialect of your users.
     </p>
     <p>

--- a/examples/editor-sdk-document-dialect/public/index.html
+++ b/examples/editor-sdk-document-dialect/public/index.html
@@ -22,6 +22,7 @@
     <p>
       <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
     </p>
+    
     <grammarly-editor-plugin config.activation="immediate">
       <div contenteditable="true">
         <p>

--- a/examples/editor-sdk-document-dialect/public/index.html
+++ b/examples/editor-sdk-document-dialect/public/index.html
@@ -12,12 +12,12 @@
   <body>
     <h2>Document Dialect (Auto Browser)</h2>
     <p>
-      By default, Grammarly sets an appropriate dialect based on your user's
+      By default, Grammarly sets an appropriate English dialect according to your user's
       browser settings (<code>"auto-browser"</code>).
     </p>
     <p>
-      Alternatively, you can configure Grammarly to set an appropriate dialect based on your
-      user's written text (<code>"auto-text"</code>).
+      Alternatively, you can configure Grammarly to set a dialect according to your
+      user's written text (<code>"auto-text"</code>) or the expected English dialect of your users.
     </p>
     <p>
       <strong>Try the Grammarly Editor Plugin in the text area below!</strong>

--- a/examples/editor-sdk-document-dialect/readme.md
+++ b/examples/editor-sdk-document-dialect/readme.md
@@ -8,7 +8,7 @@ You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/
 
 ## How it works
 
-[index.html](./public/index.html) and the other HTML files in this repository contain `<div contenteditable>` elements. These elements are wrapped with the `<grammarly-editor-plugin>` web component so that Grammarly suggestions will be displayed in them. 
+[index.html](./public/index.html) and the other HTML files in this repository contain `<div contenteditable>` elements. These elements are wrapped with the `<grammarly-editor-plugin>` web component so that Grammarly suggestions display in the specified text areas. 
 
 HTML attributes on `<grammarly-editor-plugin>` toward the bottom of the file configure the Grammarly Text Editor SDK. See [index.html](./public/index.html) for the full code example.
 

--- a/examples/editor-sdk-document-dialect/readme.md
+++ b/examples/editor-sdk-document-dialect/readme.md
@@ -1,6 +1,6 @@
 # Grammarly Text Editor SDK with documentDialect
 
-This demo shows how to add [documentDialect](https://developer.grammarly.com/docs/api/editor-sdk/editorconfig#documentdialect) to the [Grammarly Text Editor SDK](https://developer.grammarly.com/).
+This demo shows how to configure [documentDialect](https://developer.grammarly.com/docs/api/editor-sdk/editorconfig#documentdialect) for the [Grammarly Text Editor Plugin](https://developer.grammarly.com/).
 
 ## Try the demo
 
@@ -10,7 +10,7 @@ You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/
 
 [index.html](./public/index.html) and the other HTML files in this repository contain `<div contenteditable>` elements. These elements are wrapped with the `<grammarly-editor-plugin>` web component so that Grammarly suggestions display in the specified text areas. 
 
-HTML attributes on `<grammarly-editor-plugin>` toward the bottom of the file configure the Grammarly Text Editor SDK. See [index.html](./public/index.html) for the full code example.
+HTML attributes on `<grammarly-editor-plugin>` toward the bottom of the file configure the Grammarly Text Editor Plugin. See [index.html](./public/index.html) for the full code example.
 
 ## Get the code
 

--- a/examples/editor-sdk-document-domain/public/domains/academic-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/academic-domain.html
@@ -12,12 +12,12 @@
   <body>
     <h2>Document Domain (Academic)</h2>
     <p>
-      The Grammarly Editor Plugin on this page is set to use the
+      The Grammarly Text Editor Plugin on this page is set to use the
       <code>"academic"</code> domain setting. This domain is designed to 
       analyze text against stricter, academic writing criteria.
     </p>
     <p>
-      <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
+      <strong>Try the Grammarly Text Editor Plugin in the text area below!</strong>
     </p>
     <grammarly-editor-plugin config.activation="immediate" config.documentDomain="academic">
       <div contenteditable="true">
@@ -27,7 +27,7 @@
       </div>
     </grammarly-editor-plugin>
     <p>
-      The configured dialect can not be overrided with the Grammarly button.
+     The configured dialect cannot be overriden with the Grammarly button.
     </p>
     <p>
       <a href="/index.html">Return to the index.</a>

--- a/examples/editor-sdk-document-domain/public/domains/academic-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/academic-domain.html
@@ -27,7 +27,7 @@
       </div>
     </grammarly-editor-plugin>
     <p>
-      The configured domain cannot be overridden from the settings menu (accessed by clicking on the Grammarly button).
+      The configured domain cannot be overridden by your users from the settings menu.
     </p>
     <p>
       <a href="/index.html">Return to the index.</a>

--- a/examples/editor-sdk-document-domain/public/domains/academic-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/academic-domain.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <title>Demo App</title>
+    <title>Document Domain demo</title>
     <link rel="stylesheet" href="/style.css">
   </head>
   <body>
@@ -27,12 +27,12 @@
       </div>
     </grammarly-editor-plugin>
     <p>
-     The configured dialect cannot be overriden with the Grammarly button.
+      The configured domain cannot be overridden from the settings menu (accessed by clicking on the Grammarly button).
     </p>
     <p>
       <a href="/index.html">Return to the index.</a>
     </p>
 
-    <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.5?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.8?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-document-domain/public/domains/academic-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/academic-domain.html
@@ -27,6 +27,9 @@
       </div>
     </grammarly-editor-plugin>
     <p>
+      The configured dialect can not be overrided with the Grammarly button.
+    </p>
+    <p>
       <a href="/index.html">Return to the index.</a>
     </p>
 

--- a/examples/editor-sdk-document-domain/public/domains/academic-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/academic-domain.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <title>Demo App</title>
+  </head>
+  <body>
+    <h2>Document Domain (Academic)</h2>
+    <p>
+      The Grammarly Editor Plugin on this page is set to use the
+      <code>"academic"</code> domain setting. This domain is designed to 
+      analyze text against stricter, academic writing criteria.
+    </p>
+    <p>
+      <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
+    </p>
+    <grammarly-editor-plugin config.activation="immediate" config.documentDomain="academic">
+      <div contenteditable="true">
+        <p>
+          You'll find that suggestions can possibly be different in different domains.
+        </p>
+      </div>
+    </grammarly-editor-plugin>
+    <p>
+      <a href="/index.html">Return to the index.</a>
+    </p>
+
+    <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.5?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+  </body>
+</html>

--- a/examples/editor-sdk-document-domain/public/domains/academic-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/academic-domain.html
@@ -7,6 +7,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Demo App</title>
+    <link rel="stylesheet" href="/style.css">
   </head>
   <body>
     <h2>Document Domain (Academic)</h2>

--- a/examples/editor-sdk-document-domain/public/domains/business-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/business-domain.html
@@ -12,12 +12,12 @@
   <body>
     <h2>Document Domain (Business)</h2>
     <p>
-      The Grammarly Editor Plugin on this page is set to use the
+      The Grammarly Text Editor Plugin on this page is set to use the
       <code>"business"</code> domain setting. This domain is designed to 
       analyze text against formal writing criteria.
     </p>
     <p>
-      <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
+      <strong>Try the Grammarly Text Editor Plugin in the text area below!</strong>
     </p>
     <grammarly-editor-plugin config.activation="immediate" config.documentDomain="business">
       <div contenteditable="true">
@@ -27,7 +27,7 @@
       </div>
     </grammarly-editor-plugin>
     <p>
-      The configured dialect can not be overrided with the Grammarly button.
+      The configured dialect can not be overridden with the Grammarly button.
     </p>
     <p>
       <a href="/index.html">Return to the index.</a>

--- a/examples/editor-sdk-document-domain/public/domains/business-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/business-domain.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <title>Demo App</title>
+  </head>
+  <body>
+    <h2>Document Domain (Business)</h2>
+    <p>
+      The Grammarly Editor Plugin on this page is set to use the
+      <code>"business"</code> domain setting. This domain is designed to 
+      analyze text against formal writing criteria.
+    </p>
+    <p>
+      <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
+    </p>
+    <grammarly-editor-plugin config.activation="immediate" config.documentDomain="business">
+      <div contenteditable="true">
+        <p>
+          You'll find that suggestions can possibly be different in different domains.
+        </p>
+      </div>
+    </grammarly-editor-plugin>
+    <p>
+      <a href="/index.html">Return to the index.</a>
+    </p>
+
+    <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.5?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+  </body>
+</html>

--- a/examples/editor-sdk-document-domain/public/domains/business-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/business-domain.html
@@ -27,7 +27,7 @@
       </div>
     </grammarly-editor-plugin>
     <p>
-      The configured domain cannot be overridden from the settings menu (accessed by clicking on the Grammarly button).
+      The configured domain cannot be overridden by your users from the settings menu.
     </p>
     <p>
       <a href="/index.html">Return to the index.</a>

--- a/examples/editor-sdk-document-domain/public/domains/business-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/business-domain.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <title>Demo App</title>
+    <title>Document Domain demo</title>
     <link rel="stylesheet" href="/style.css">
   </head>
   <body>
@@ -27,12 +27,12 @@
       </div>
     </grammarly-editor-plugin>
     <p>
-      The configured dialect can not be overridden with the Grammarly button.
+      The configured domain cannot be overridden from the settings menu (accessed by clicking on the Grammarly button).
     </p>
     <p>
       <a href="/index.html">Return to the index.</a>
     </p>
 
-    <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.5?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.8?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-document-domain/public/domains/business-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/business-domain.html
@@ -27,6 +27,9 @@
       </div>
     </grammarly-editor-plugin>
     <p>
+      The configured dialect can not be overrided with the Grammarly button.
+    </p>
+    <p>
       <a href="/index.html">Return to the index.</a>
     </p>
 

--- a/examples/editor-sdk-document-domain/public/domains/business-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/business-domain.html
@@ -7,6 +7,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Demo App</title>
+    <link rel="stylesheet" href="/style.css">
   </head>
   <body>
     <h2>Document Domain (Business)</h2>

--- a/examples/editor-sdk-document-domain/public/domains/casual-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/casual-domain.html
@@ -29,6 +29,9 @@
     <p>
       <a href="/index.html">Return to the index.</a>
     </p>
+    <p>
+      The configured dialect can not be overrided with the Grammarly button.
+    </p>
 
     <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.5?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>

--- a/examples/editor-sdk-document-domain/public/domains/casual-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/casual-domain.html
@@ -12,12 +12,12 @@
   <body>
     <h2>Document Domain (Casual)</h2>
     <p>
-      The Grammarly Editor Plugin on this page is set to use the
+      The Grammarly Text Editor Plugin on this page is set to use the
       <code>"casual"</code> domain setting. This domain is designed for
       informal types of writing and ignores most style issues.
     </p>
     <p>
-      <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
+      <strong>Try the Grammarly Text Editor Plugin in the text area below!</strong>
     </p>
     <grammarly-editor-plugin config.activation="immediate" config.documentDomain="casual">
       <div contenteditable="true">
@@ -30,7 +30,7 @@
       <a href="/index.html">Return to the index.</a>
     </p>
     <p>
-      The configured dialect can not be overrided with the Grammarly button.
+      The configured dialect can not be overridden with the Grammarly button.
     </p>
 
     <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.5?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>

--- a/examples/editor-sdk-document-domain/public/domains/casual-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/casual-domain.html
@@ -27,7 +27,7 @@
       </div>
     </grammarly-editor-plugin>
     <p>
-      The configured domain cannot be overridden from the settings menu (accessed by clicking on the Grammarly button).
+      The configured domain cannot be overridden by your users from the settings menu.
     </p>
     <p>
       <a href="/index.html">Return to the index.</a>

--- a/examples/editor-sdk-document-domain/public/domains/casual-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/casual-domain.html
@@ -7,6 +7,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Demo App</title>
+    <link rel="stylesheet" href="/style.css">
   </head>
   <body>
     <h2>Document Domain (Casual)</h2>

--- a/examples/editor-sdk-document-domain/public/domains/casual-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/casual-domain.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <title>Demo App</title>
+    <title>Document Domain demo</title>
     <link rel="stylesheet" href="/style.css">
   </head>
   <body>
@@ -27,12 +27,12 @@
       </div>
     </grammarly-editor-plugin>
     <p>
-      <a href="/index.html">Return to the index.</a>
+      The configured domain cannot be overridden from the settings menu (accessed by clicking on the Grammarly button).
     </p>
     <p>
-      The configured dialect can not be overridden with the Grammarly button.
+      <a href="/index.html">Return to the index.</a>
     </p>
 
-    <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.5?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.8?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-document-domain/public/domains/casual-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/casual-domain.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <title>Demo App</title>
+  </head>
+  <body>
+    <h2>Document Domain (Casual)</h2>
+    <p>
+      The Grammarly Editor Plugin on this page is set to use the
+      <code>"casual"</code> domain setting. This domain is designed for
+      informal types of writing and ignores most style issues.
+    </p>
+    <p>
+      <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
+    </p>
+    <grammarly-editor-plugin config.activation="immediate" config.documentDomain="casual">
+      <div contenteditable="true">
+        <p>
+          You'll find that suggestions can possibly be different in different domains.
+        </p>
+      </div>
+    </grammarly-editor-plugin>
+    <p>
+      <a href="/index.html">Return to the index.</a>
+    </p>
+
+    <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.5?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+  </body>
+</html>

--- a/examples/editor-sdk-document-domain/public/domains/creative-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/creative-domain.html
@@ -27,7 +27,7 @@
       </div>
     </grammarly-editor-plugin>
     <p>
-      The configured domain cannot be overridden from the settings menu (accessed by clicking on the Grammarly button).
+      The configured domain cannot be overridden by your users from the settings menu.
     </p>
     <p>
       <a href="/index.html">Return to the index.</a>

--- a/examples/editor-sdk-document-domain/public/domains/creative-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/creative-domain.html
@@ -7,6 +7,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Demo App</title>
+    <link rel="stylesheet" href="/style.css">
   </head>
   <body>
     <h2>Document Domain (Creative)</h2>

--- a/examples/editor-sdk-document-domain/public/domains/creative-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/creative-domain.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <title>Demo App</title>
+  </head>
+  <body>
+    <h2>Document Domain (Creative)</h2>
+    <p>
+      The Grammarly Editor Plugin on this page is set to use the
+      <code>"creative"</code> domain setting. This domain is designed to
+      intentionally bend grammar rules to achieve certain effects.
+    </p>
+    <p>
+      <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
+    </p>
+    <grammarly-editor-plugin config.activation="immediate" config.documentDomain="creative">
+      <div contenteditable="true">
+        <p>
+          You'll find that suggestions can possibly be different in different domains.
+        </p>
+      </div>
+    </grammarly-editor-plugin>
+    <p>
+      <a href="/index.html">Return to the index.</a>
+    </p>
+
+    <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.5?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+  </body>
+</html>

--- a/examples/editor-sdk-document-domain/public/domains/creative-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/creative-domain.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <title>Demo App</title>
+    <title>Document Domain demo</title>
     <link rel="stylesheet" href="/style.css">
   </head>
   <body>
@@ -27,12 +27,12 @@
       </div>
     </grammarly-editor-plugin>
     <p>
-      The configured dialect can not be overridden with the Grammarly button.
+      The configured domain cannot be overridden from the settings menu (accessed by clicking on the Grammarly button).
     </p>
     <p>
       <a href="/index.html">Return to the index.</a>
     </p>
 
-    <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.5?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.8?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-document-domain/public/domains/creative-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/creative-domain.html
@@ -12,12 +12,12 @@
   <body>
     <h2>Document Domain (Creative)</h2>
     <p>
-      The Grammarly Editor Plugin on this page is set to use the
+      The Grammarly Text Editor Plugin on this page is set to use the
       <code>"creative"</code> domain setting. This domain is designed to
       intentionally bend grammar rules to achieve certain effects.
     </p>
     <p>
-      <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
+      <strong>Try the Grammarly Text Editor Plugin in the text area below!</strong>
     </p>
     <grammarly-editor-plugin config.activation="immediate" config.documentDomain="creative">
       <div contenteditable="true">
@@ -27,7 +27,7 @@
       </div>
     </grammarly-editor-plugin>
     <p>
-      The configured dialect can not be overrided with the Grammarly button.
+      The configured dialect can not be overridden with the Grammarly button.
     </p>
     <p>
       <a href="/index.html">Return to the index.</a>

--- a/examples/editor-sdk-document-domain/public/domains/creative-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/creative-domain.html
@@ -27,6 +27,9 @@
       </div>
     </grammarly-editor-plugin>
     <p>
+      The configured dialect can not be overrided with the Grammarly button.
+    </p>
+    <p>
       <a href="/index.html">Return to the index.</a>
     </p>
 

--- a/examples/editor-sdk-document-domain/public/domains/mail-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/mail-domain.html
@@ -7,6 +7,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Demo App</title>
+    <link rel="stylesheet" href="/style.css">
   </head>
   <body>
     <h2>Document Domain (Mail)</h2>

--- a/examples/editor-sdk-document-domain/public/domains/mail-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/mail-domain.html
@@ -27,7 +27,7 @@
       </div>
     </grammarly-editor-plugin>
     <p>
-      The configured domain cannot be overridden from the settings menu (accessed by clicking on the Grammarly button).
+      The configured domain cannot be overridden by your users from the settings menu.
     </p>
     <p>
       <a href="/index.html">Return to the index.</a>

--- a/examples/editor-sdk-document-domain/public/domains/mail-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/mail-domain.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <title>Demo App</title>
+  </head>
+  <body>
+    <h2>Document Domain (Mail)</h2>
+    <p>
+      The Grammarly Editor Plugin on this page is set to use the
+      <code>"mail"</code> domain setting. This domain is designed to
+      help ensure that your email communication is engaging.
+    </p>
+    <p>
+      <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
+    </p>
+    <grammarly-editor-plugin config.activation="immediate" config.documentDomain="mail">
+      <div contenteditable="true">
+        <p>
+          You'll find that suggestions can possibly be different in different domains.
+        </p>
+      </div>
+    </grammarly-editor-plugin>
+    <p>
+      <a href="/index.html">Return to the index.</a>
+    </p>
+
+    <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.5?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+  </body>
+</html>

--- a/examples/editor-sdk-document-domain/public/domains/mail-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/mail-domain.html
@@ -12,12 +12,12 @@
   <body>
     <h2>Document Domain (Mail)</h2>
     <p>
-      The Grammarly Editor Plugin on this page is set to use the
+      The Grammarly Text Editor Plugin on this page is set to use the
       <code>"mail"</code> domain setting. This domain is designed to
       help ensure that your email communication is engaging.
     </p>
     <p>
-      <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
+      <strong>Try the Grammarly Text Editor Plugin in the text area below!</strong>
     </p>
     <grammarly-editor-plugin config.activation="immediate" config.documentDomain="mail">
       <div contenteditable="true">
@@ -27,7 +27,7 @@
       </div>
     </grammarly-editor-plugin>
     <p>
-      The configured dialect can not be overrided with the Grammarly button.
+      The configured dialect can not be overridden with the Grammarly button.
     </p>
     <p>
       <a href="/index.html">Return to the index.</a>

--- a/examples/editor-sdk-document-domain/public/domains/mail-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/mail-domain.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <title>Demo App</title>
+    <title>Document Domain demo</title>
     <link rel="stylesheet" href="/style.css">
   </head>
   <body>
@@ -27,12 +27,12 @@
       </div>
     </grammarly-editor-plugin>
     <p>
-      The configured dialect can not be overridden with the Grammarly button.
+      The configured domain cannot be overridden from the settings menu (accessed by clicking on the Grammarly button).
     </p>
     <p>
       <a href="/index.html">Return to the index.</a>
     </p>
 
-    <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.5?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.8?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-document-domain/public/domains/mail-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/mail-domain.html
@@ -27,6 +27,9 @@
       </div>
     </grammarly-editor-plugin>
     <p>
+      The configured dialect can not be overrided with the Grammarly button.
+    </p>
+    <p>
       <a href="/index.html">Return to the index.</a>
     </p>
 

--- a/examples/editor-sdk-document-domain/public/index.html
+++ b/examples/editor-sdk-document-domain/public/index.html
@@ -36,11 +36,11 @@
     <p>
       Explore these other pages to try different domain configurations:
       <ul>
-        <li><a href="/domains/academic-domain.html">Academic</a> (<code>"academic"</code>)
-        <li><a href="/domains/business-domain.html">Business</a> (<code>"business"</code>)
-        <li><a href="/domains/mail-domain.html">Mail</a> (<code>"mail"</code>)
-        <li><a href="/domains/casual-domain.html">Casual</a> (<code>"casual"</code>)
-        <li><a href="/domains/creative-domain.html">Creative</a> (<code>"creative"</code>)
+        <li><a href="/domains/academic-domain.html">Academic</a> (<code>"academic"</code>)</li>
+        <li><a href="/domains/business-domain.html">Business</a> (<code>"business"</code>)</li>
+        <li><a href="/domains/mail-domain.html">Mail</a> (<code>"mail"</code>)</li>
+        <li><a href="/domains/casual-domain.html">Casual</a> (<code>"casual"</code>)</li>
+        <li><a href="/domains/creative-domain.html">Creative</a> (<code>"creative"</code>)</li>
       </ul>
     </p>
 

--- a/examples/editor-sdk-document-domain/public/index.html
+++ b/examples/editor-sdk-document-domain/public/index.html
@@ -7,6 +7,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Demo App</title>
+    <link rel="stylesheet" href="/style.css">
   </head>
   <body>
     <h2>Document Domain (General)</h2>

--- a/examples/editor-sdk-document-domain/public/index.html
+++ b/examples/editor-sdk-document-domain/public/index.html
@@ -20,6 +20,7 @@
     <p>
       <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
     </p>
+
     <grammarly-editor-plugin config.activation="immediate">
       <div contenteditable="true">
         <p>
@@ -27,6 +28,10 @@
         </p>
       </div>
     </grammarly-editor-plugin>
+
+    <p>
+      The configured dialect can not be overrided with the Grammarly button.
+    </p>
 
     <p>
       Explore these other pages to try different domain configurations:

--- a/examples/editor-sdk-document-domain/public/index.html
+++ b/examples/editor-sdk-document-domain/public/index.html
@@ -12,13 +12,13 @@
   <body>
     <h2>Document Domain (General)</h2>
     <p>
-      By default, Grammarly sets the domain—the style or type of writing to be analyzed—of the document to a medium level of strictness (<code>"general"</code>).
+      The document domain is the expected style or type of writing and helps Grammarly give appropriate suggestions. For instance, someone may want to use strictly formal writing for an academic paper, but when they're writing a poem, they want to be free to break grammar rules. By default, the Grammarly Text Editor Plugin has a document domain of <code>"general"</code>, which provides a medium level of strictness that's applicable to a wide range of writing. 
     </p>
     <p>
-      Alternatively, you can configure Grammarly to analyze text according to a different, more specific domain to get the most accurate and relevant writing suggestions for your users.
+      Alternatively, you can configure the Grammarly Text Editor Plugin to analyze text according to a different, more specific domain to get the most accurate and relevant writing suggestions for your users.
     </p>
     <p>
-      <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
+      <strong>Try the Grammarly Text Editor Plugin in the text area below!</strong>
     </p>
 
     <grammarly-editor-plugin config.activation="immediate">
@@ -30,7 +30,7 @@
     </grammarly-editor-plugin>
 
     <p>
-      The configured dialect can not be overrided with the Grammarly button.
+      The configured dialect can not be overridden with the Grammarly button.
     </p>
 
     <p>

--- a/examples/editor-sdk-document-domain/public/index.html
+++ b/examples/editor-sdk-document-domain/public/index.html
@@ -31,7 +31,7 @@
     </grammarly-editor-plugin>
 
     <p>
-      The configured domain cannot be overridden from the settings menu (accessed by clicking on the Grammarly button).
+      The configured domain cannot be overridden by your users from the settings menu.
     </p>
 
     <p>

--- a/examples/editor-sdk-document-domain/public/index.html
+++ b/examples/editor-sdk-document-domain/public/index.html
@@ -7,56 +7,36 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Demo App</title>
-    <style>
-      * {
-        box-sizing: border-box;
-      }
-
-      body {
-        font-family: sans-serif;
-      }
-
-      input,
-      textarea,
-      [contenteditable] {
-        font: inherit;
-        line-height: 1.5;
-        width: 600px;
-        padding: 8px 12px;
-        overflow: auto;
-      }
-
-      label {
-        display: block;
-        margin-bottom: 4px;
-      }
-
-      [contenteditable] {
-        height: 10rem;
-        border: 1px solid;
-        resize: both;
-      }
-    </style>
   </head>
   <body>
-    <h2>General Domain</h2>
-      <grammarly-editor-plugin config.documentDomain="general">
-        <div contenteditable="true">
-          <p>
-            You'll find that suggestions can possibly be different in different domains.
-          </p>
-        </div>
-      </grammarly-editor-plugin>
+    <h2>Document Domain (General)</h2>
+    <p>
+      By default, Grammarly sets the domain—the style or type of writing to be analyzed—of the document to a medium level of strictness (<code>"general"</code>).
+    </p>
+    <p>
+      Alternatively, you can configure Grammarly to analyze text according to a different, more specific domain to get the most accurate and relevant writing suggestions for your users.
+    </p>
+    <p>
+      <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
+    </p>
+    <grammarly-editor-plugin config.activation="immediate">
+      <div contenteditable="true">
+        <p>
+          You'll find that suggestions can possibly be different in different domains.
+        </p>
+      </div>
+    </grammarly-editor-plugin>
 
-
-    <h2>Academic Domain</h2>
-      <grammarly-editor-plugin config.documentDomain="academic">
-        <div contenteditable="true">
-          <p>
-            You'll find that suggestions can possibly be different in different domains.
-          </p>
-        </div>
-      </grammarly-editor-plugin>
+    <p>
+      Explore these other pages to try different domain configurations:
+      <ul>
+        <li><a href="/domains/academic-domain.html">Academic</a> (<code>"academic"</code>)
+        <li><a href="/domains/business-domain.html">Business</a> (<code>"business"</code>)
+        <li><a href="/domains/mail-domain.html">Mail</a> (<code>"mail"</code>)
+        <li><a href="/domains/casual-domain.html">Casual</a> (<code>"casual"</code>)
+        <li><a href="/domains/creative-domain.html">Creative</a> (<code>"creative"</code>)
+      </ul>
+    </p>
 
     <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.5?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>

--- a/examples/editor-sdk-document-domain/public/index.html
+++ b/examples/editor-sdk-document-domain/public/index.html
@@ -6,16 +6,17 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <title>Demo App</title>
+    <title>Document Domain demo</title>
     <link rel="stylesheet" href="/style.css">
   </head>
   <body>
     <h2>Document Domain (General)</h2>
     <p>
-      The document domain is the expected style or type of writing and helps Grammarly give appropriate suggestions. For instance, someone may want to use strictly formal writing for an academic paper, but when they're writing a poem, they want to be free to break grammar rules. By default, the Grammarly Text Editor Plugin has a document domain of <code>"general"</code>, which provides a medium level of strictness that's applicable to a wide range of writing. 
+      The document domain is the expected style or type of writing for your users and helps Grammarly offer appropriate writing suggestions. For instance, someone may want to use strictly formal writing for an academic paper, but when they're writing a poem, they want to be free to break grammar rules. 
+      By default, the Grammarly Text Editor Plugin has a document domain of <code>"general"</code>, which provides a medium level of strictness that's applicable to a wide range of writing. 
     </p>
     <p>
-      Alternatively, you can configure the Grammarly Text Editor Plugin to analyze text according to a different, more specific domain to get the most accurate and relevant writing suggestions for your users.
+      You can configure the Grammarly Text Editor Plugin to analyze text according to a different, more specific domain to get the most accurate and relevant writing suggestions for your users. On this page, the plugin is set to use the <code>"general"</code> domain setting.
     </p>
     <p>
       <strong>Try the Grammarly Text Editor Plugin in the text area below!</strong>
@@ -30,7 +31,7 @@
     </grammarly-editor-plugin>
 
     <p>
-      The configured dialect can not be overridden with the Grammarly button.
+      The configured domain cannot be overridden from the settings menu (accessed by clicking on the Grammarly button).
     </p>
 
     <p>

--- a/examples/editor-sdk-document-domain/public/style.css
+++ b/examples/editor-sdk-document-domain/public/style.css
@@ -1,0 +1,34 @@
+<style>
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: sans-serif;
+}
+
+ul li {
+  line-height: 1.5em;
+}
+
+input,
+textarea,
+[contenteditable] {
+  font: inherit;
+  line-height: 1.5;
+  width: 600px;
+  padding: 8px 12px;
+  overflow: auto;
+}
+
+label {
+  display: block;
+  margin-bottom: 4px;
+}
+
+[contenteditable] {
+  height: 10rem;
+  border: 1px solid;
+  resize: both;
+}
+</style>

--- a/examples/editor-sdk-document-domain/readme.md
+++ b/examples/editor-sdk-document-domain/readme.md
@@ -1,6 +1,6 @@
 # Grammarly Text Editor SDK with documentDomain
 
-This demo shows how to add [documentDomain](https://developer.grammarly.com/docs/api/editor-sdk/editorconfig#documentdomain) to the [Grammarly Text Editor SDK](https://developer.grammarly.com/).
+This demo shows how to configure the [documentDomain](https://developer.grammarly.com/docs/api/editor-sdk/editorconfig#documentdomain) for the [Grammarly Text Editor SDK](https://developer.grammarly.com/).
 
 ## Try the demo
 
@@ -10,7 +10,7 @@ You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/
 
 [index.html](./public/index.html) and the other HTML files in this repository contain `<div contenteditable>` elements. These elements are wrapped with the `<grammarly-editor-plugin>` web component so that Grammarly suggestions display in the specified text areas.
 
-HTML attributes on `<grammarly-editor-plugin>` toward the bottom of the file configure the Grammarly Text Editor SDK. See [index.html](./public/index.html) for the full code example.
+HTML attributes on `<grammarly-editor-plugin>` toward the bottom of the file configure the Grammarly Text Editor Plugin. See [index.html](./public/index.html) for the full code example.
 
 ## Get the code
 

--- a/examples/editor-sdk-document-domain/readme.md
+++ b/examples/editor-sdk-document-domain/readme.md
@@ -8,7 +8,7 @@ You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/
 
 ## How it works
 
-[index.html](./public/index.html) and the other HTML files in this repository contain `<div contenteditable>` elements. These elements are wrapped with the `<grammarly-editor-plugin>` web component so that Grammarly suggestions display in the specified text areas.
+[index.html](./public/index.html) and the other HTML files in this repository contain `div contenteditable` elements. We've added the Grammarly Text Editor Plugin to these elements by wrapping them with the `<grammarly-editor-plugin> tag. The plugin displays Grammarly suggestions as users enter text. 
 
 HTML attributes on `<grammarly-editor-plugin>` toward the bottom of the file configure the Grammarly Text Editor Plugin. See [index.html](./public/index.html) for the full code example.
 

--- a/examples/editor-sdk-document-domain/readme.md
+++ b/examples/editor-sdk-document-domain/readme.md
@@ -8,7 +8,7 @@ You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/
 
 ## How it works
 
-[index.html](./public/index.html) and the other HTML files in this repository contain `div contenteditable` elements. We've added the Grammarly Text Editor Plugin to these elements by wrapping them with the `<grammarly-editor-plugin> tag. The plugin displays Grammarly suggestions as users enter text. 
+[index.html](./public/index.html) and the other HTML files in this repository contain `div contenteditable` elements. We've added the Grammarly Text Editor Plugin to these elements by wrapping them with the `<grammarly-editor-plugin>` web component. The plugin displays Grammarly suggestions as users enter text. 
 
 HTML attributes on `<grammarly-editor-plugin>` toward the bottom of the file configure the Grammarly Text Editor Plugin. See [index.html](./public/index.html) for the full code example.
 

--- a/examples/editor-sdk-document-domain/readme.md
+++ b/examples/editor-sdk-document-domain/readme.md
@@ -1,6 +1,6 @@
 # Grammarly Text Editor SDK with documentDomain
 
-This demo shows how to add [documentDomain](https://developer.grammarly.com/docs/api/editor-sdk/editorconfig#documentdomain) to  [Grammarly Text Editor SDK](https://developer.grammarly.com/).
+This demo shows how to add [documentDomain](https://developer.grammarly.com/docs/api/editor-sdk/editorconfig#documentdomain) to the [Grammarly Text Editor SDK](https://developer.grammarly.com/).
 
 ## Try the demo
 
@@ -8,7 +8,9 @@ You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/
 
 ## How it works
 
-[index.html](./public/index.html) contains `<div contenteditable>` elements. These elements are wrapped with the `<grammarly-editor-plugin>` tag so that Grammarly suggestions will be displayed in them. JavaScript code toward the bottom of the file configures the Grammarly Text Editor SDK. See [index.html](./public/index.html) for the full code example.
+[index.html](./public/index.html) and the other HTML files in this repository contain `<div contenteditable>` elements. These elements are wrapped with the `<grammarly-editor-plugin>` web component so that Grammarly suggestions display in the specified text areas.
+
+HTML attributes on `<grammarly-editor-plugin>` toward the bottom of the file configure the Grammarly Text Editor SDK. See [index.html](./public/index.html) for the full code example.
 
 ## Get the code
 


### PR DESCRIPTION
Similar goals to https://github.com/grammarly/grammarly-for-developers/pull/395.

To test, create a codesandbox from https://github.com/AndrewDiMola/grammarly-for-developers/tree/refactor-document-domain-example/examples/editor-sdk-document-domain.

(https://codesandbox.io/s/github/andrewdimola/grammarly-for-developers/tree/refactor-document-domain-example/examples/editor-sdk-document-domain?file=/public/index.html)