### PR TITLE
Fix links in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The [Grammarly for Developers blog](https://www.grammarly.com/blog/developer/) i
 
 <!-- BLOG-POST-LIST:START -->
 - [5 Strategies for Using Writing to Level Up Your Technical Career](https://www.grammarly.com/blog/developer/5-strategies-using-writing-level-up-technical-career/)
-- [How a Checkr Hack Week Project Using the Grammarly Text Editor SDK is Leading to a Fairer Future](https://www.grammarly.com/blog/developer/how-checkr-hack-week-project-using-text-editor-sdk-leading-fairer-future/)
+- [How a Checkr Hack Week Project Using the Grammarly Text Editor SDK Is Leading to a Fairer Future](https://www.grammarly.com/blog/developer/how-checkr-hack-week-project-using-text-editor-sdk-leading-fairer-future/)
 - [How I Added Grammarly’s SDK to a Google Site in 7 Minutes](https://www.grammarly.com/blog/developer/how-to-use-grammarly-text-editor-sdk-with-google-sites/)
 - [Behind the Scenes: How We Fixed Leftover Underlines in the Grammarly Text Editor Plugin](https://www.grammarly.com/blog/developer/how-we-fixed-leftover-underlines-text-editor-plugin/)
 - [How I Customized the Grammarly Text Editor Plugin’s Theme for Each Taylor Swift Album](https://www.grammarly.com/blog/developer/how-to-customize-text-editor-plugin-theme-taylor-swift-album/)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The [Grammarly for Developers blog](https://www.grammarly.com/blog/developer/) i
 
 <!-- BLOG-POST-LIST:START -->
 - [5 Strategies for Using Writing to Level Up Your Technical Career](https://www.grammarly.com/blog/developer/5-strategies-using-writing-level-up-technical-career/)
-- [How a Checkr Hack Week Project Using the Grammarly Text Editor SDK Is Leading to a Fairer Future](https://www.grammarly.com/blog/developer/how-checkr-hack-week-project-using-text-editor-sdk-leading-fairer-future/)
+- [How a Checkr Hack Week Project Using the Grammarly Text Editor SDK is Leading to a Fairer Future](https://www.grammarly.com/blog/developer/how-checkr-hack-week-project-using-text-editor-sdk-leading-fairer-future/)
 - [How I Added Grammarly’s SDK to a Google Site in 7 Minutes](https://www.grammarly.com/blog/developer/how-to-use-grammarly-text-editor-sdk-with-google-sites/)
 - [Behind the Scenes: How We Fixed Leftover Underlines in the Grammarly Text Editor Plugin](https://www.grammarly.com/blog/developer/how-we-fixed-leftover-underlines-text-editor-plugin/)
 - [How I Customized the Grammarly Text Editor Plugin’s Theme for Each Taylor Swift Album](https://www.grammarly.com/blog/developer/how-to-customize-text-editor-plugin-theme-taylor-swift-album/)

--- a/examples/editor-sdk-activation/public/activationFocus.html
+++ b/examples/editor-sdk-activation/public/activationFocus.html
@@ -14,7 +14,7 @@
     <p>
       This page has
       <a
-        href="https://developer.grammarly.com/docs/v2.x/api/editor-sdk/editorconfig#activation"
+        href="https://developer.grammarly.com/docs/api/editor-sdk/editorconfig#activation"
         >activation</a
       >
       set to "focus" (the default). Open

--- a/examples/editor-sdk-activation/public/index.html
+++ b/examples/editor-sdk-activation/public/index.html
@@ -14,7 +14,7 @@
     <p>
       This page has
       <a
-        href="https://developer.grammarly.com/docs/v2.x/api/editor-sdk/editorconfig#activation"
+        href="https://developer.grammarly.com/docs/api/editor-sdk/editorconfig#activation"
         >activation</a
       >
       set to "immediate." Visit

--- a/examples/editor-sdk-activation/readme.md
+++ b/examples/editor-sdk-activation/readme.md
@@ -1,6 +1,6 @@
 # Grammarly Text Editor SDK Activation Example
 
-This demo shows the different options for the [Grammarly Text Editor SDK](https://developer.grammarly.com/) [activation property](https://developer.grammarly.com/docs/v2.x/api/editor-sdk/editorconfig#activation).
+This demo shows the different options for the [Grammarly Text Editor SDK](https://developer.grammarly.com/) [activation property](https://developer.grammarly.com/docs/api/editor-sdk/editorconfig#activation).
 
 ## Try the demo
 

--- a/examples/readme.md
+++ b/examples/readme.md
@@ -26,7 +26,7 @@ These are starter apps you can use as you work through the quick start guide. Th
 **Note:** The quick start guide is shown when you [create a Grammarly for Developers app](https://developer.grammarly.com/apps).
 
 ### Activation
-This app shows how you can set the Text Editor Plugin's [activation property](https://developer.grammarly.com/docs/v2.x/api/editor-sdk/editorconfig#activation) to `focus` or `immediate`. 
+This app shows how you can set the Text Editor Plugin's [activation property](https://developer.grammarly.com/docs/api/editor-sdk/editorconfig#activation) to `focus` or `immediate`. 
 
    - [Activation Example App](./editor-sdk-activation/)
 
@@ -43,7 +43,7 @@ This app shows how you can configure the [document dialect](https://developer.gr
    - [Document Dialect Example App](./editor-sdk-document-dialect/)
 
 ### Document domain
-This app shows how you can configure the [document domain](https://developer.grammarly.com/docs/v1.x/api/editor-sdk/domain) for your app. 
+This app shows how you can configure the [document domain](https://developer.grammarly.com/docs/api/editor-sdk/domain) for your app. 
 
    - [Document Domain Example App](./editor-sdk-document-domain/)
 


### PR DESCRIPTION
Some links point to outdated `1.x` reference links. Otherl links point to the `2.x` version that will one day be out of date.