### PR TITLE
Refactor suggestion categories examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The [Grammarly for Developers blog](https://www.grammarly.com/blog/developer/) i
 
 <!-- BLOG-POST-LIST:START -->
 - [5 Strategies for Using Writing to Level Up Your Technical Career](https://www.grammarly.com/blog/developer/5-strategies-using-writing-level-up-technical-career/)
-- [How a Checkr Hack Week Project Using the Grammarly Text Editor SDK is Leading to a Fairer Future](https://www.grammarly.com/blog/developer/how-checkr-hack-week-project-using-text-editor-sdk-leading-fairer-future/)
+- [How a Checkr Hack Week Project Using the Grammarly Text Editor SDK Is Leading to a Fairer Future](https://www.grammarly.com/blog/developer/how-checkr-hack-week-project-using-text-editor-sdk-leading-fairer-future/)
 - [How I Added Grammarly’s SDK to a Google Site in 7 Minutes](https://www.grammarly.com/blog/developer/how-to-use-grammarly-text-editor-sdk-with-google-sites/)
 - [Behind the Scenes: How We Fixed Leftover Underlines in the Grammarly Text Editor Plugin](https://www.grammarly.com/blog/developer/how-we-fixed-leftover-underlines-text-editor-plugin/)
 - [How I Customized the Grammarly Text Editor Plugin’s Theme for Each Taylor Swift Album](https://www.grammarly.com/blog/developer/how-to-customize-text-editor-plugin-theme-taylor-swift-album/)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The [Grammarly for Developers blog](https://www.grammarly.com/blog/developer/) i
 
 <!-- BLOG-POST-LIST:START -->
 - [5 Strategies for Using Writing to Level Up Your Technical Career](https://www.grammarly.com/blog/developer/5-strategies-using-writing-level-up-technical-career/)
-- [How a Checkr Hack Week Project Using the Grammarly Text Editor SDK Is Leading to a Fairer Future](https://www.grammarly.com/blog/developer/how-checkr-hack-week-project-using-text-editor-sdk-leading-fairer-future/)
+- [How a Checkr Hack Week Project Using the Grammarly Text Editor SDK is Leading to a Fairer Future](https://www.grammarly.com/blog/developer/how-checkr-hack-week-project-using-text-editor-sdk-leading-fairer-future/)
 - [How I Added Grammarly’s SDK to a Google Site in 7 Minutes](https://www.grammarly.com/blog/developer/how-to-use-grammarly-text-editor-sdk-with-google-sites/)
 - [Behind the Scenes: How We Fixed Leftover Underlines in the Grammarly Text Editor Plugin](https://www.grammarly.com/blog/developer/how-we-fixed-leftover-underlines-text-editor-plugin/)
 - [How I Customized the Grammarly Text Editor Plugin’s Theme for Each Taylor Swift Album](https://www.grammarly.com/blog/developer/how-to-customize-text-editor-plugin-theme-taylor-swift-album/)

--- a/examples/editor-sdk-suggestions-config/public/index.html
+++ b/examples/editor-sdk-suggestions-config/public/index.html
@@ -19,7 +19,7 @@
       <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
       <p>In this example, writing suggestions for unnecessary ellipsis are turned "on".</p>
     </p>
-    <grammarly-editor-plugin activation="immediate" config.suggestionCategories.unnecessaryEllipses="on">
+    <grammarly-editor-plugin config.activation="immediate" config.suggestionCategories.unnecessaryEllipses="on">
       <div contenteditable="true">
         <p>
           Please bring me a pencil, eraser and notebook...

--- a/examples/editor-sdk-suggestions-config/public/index.html
+++ b/examples/editor-sdk-suggestions-config/public/index.html
@@ -7,55 +7,36 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Demo App</title>
-    <style>
-      * {
-        box-sizing: border-box;
-      }
-
-      body {
-        font-family: sans-serif;
-      }
-
-      input,
-      textarea,
-      [contenteditable] {
-        font: inherit;
-        line-height: 1.5;
-        width: 600px;
-        padding: 8px 12px;
-        overflow: auto;
-      }
-
-      label {
-        display: block;
-        margin-bottom: 4px;
-      }
-
-      [contenteditable] {
-        height: 10rem;
-        border: 1px solid;
-        resize: both;
-      }
-    </style>
+    <link rel="stylesheet" href="/style.css">
   </head>
   <body>
-    <h2>Default suggestion categories</h2>
-      <grammarly-editor-plugin>
-        <div contenteditable="true">
-          <p>
-            Please bring me a pencil, eraser and notebook.
-          </p>
-        </div>
-      </grammarly-editor-plugin>
-
-    <h2>Oxford commas turned on</h2>
-      <grammarly-editor-plugin config.suggestionCategories.oxfordComma="on">
-        <div contenteditable="true">
-          <p>
-            Please bring me a pencil, eraser and notebook.
-          </p>
-        </div>
-      </grammarly-editor-plugin>
+    <h2>Suggestion Categories (Default)</h2>
+    <p>
+      By default, the Grammarly Text Editor SDK mutes (turns "off") seven categories of writing suggestions.
+        <ul>
+          <li><strong>Conjunctions at the start of a sentence:</strong> Suggestions for using conjunctions such as "but" and "and" at the beginning of sentences (<code>"conjunctionAtStartOfSentence"</code>).</li>
+          <li><strong>Prepositions at the end of a sentence:</strong> Suggestions for using prepositions such as "with" and "in" at the end of sentences (<code>"prepositionAtTheEndOfSentence"</code>).</li>
+          <li><strong>Informal academic pronouns:</strong> Suggestions for using personal pronouns such as "I" and "you" in academic writing (<code>"informalPronounsAcademic"</code>).</li>
+          <li><strong>The Oxford comma:</strong> Suggestions for adding the Oxford comma after the second-to-last item in a list of things. (<code>"oxfordComma"</code>).</li>
+          <li><strong>The passive voice:</strong> Suggestions regarding use of the passive voice (<code>"passiveVoice"</code>).</li>
+          <li><strong>Unnecessary Ellipsis:</strong> Suggestions regarding unnecessary use of ellipses (...) (<code>"unnecessaryEllipses"</code>).</li>
+          <li><strong>Stylistic fragments:</strong> Suggestions for completing all incomplete sentences, including stylistic sentence fragments that may be intentional (<code>"stylisticFragments"</code>).</li>
+        </ul>
+    </p>
+    <p>
+      When a suggestion category is set to "off", as is the case with the above categories of suggestions with default settings, any suggestions belonging to that category will be muted (not visible to the user);
+      however, if a user has connected their Grammarly account to your application, the full set of customized suggestions from their user profile will always take precedence.
+    </p>
+    <grammarly-editor-plugin>
+      <div contenteditable="true">
+        <p>
+          Please bring me a pencil, eraser and notebook.
+        </p>
+      </div>
+    </grammarly-editor-plugin>
+    <p>
+      Configuring suggestion categories is available only on the Grammarly Text Editor SDK Plus plan.
+    </p>
 
       <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.5?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>

--- a/examples/editor-sdk-suggestions-config/public/index.html
+++ b/examples/editor-sdk-suggestions-config/public/index.html
@@ -41,13 +41,13 @@
     <p>
       By default, the Grammarly Text Editor SDK mutes (turns "off") seven categories of writing suggestions.
         <ul>
+          <li><strong>Unnecessary ellipsis:</strong> Suggestions regarding unnecessary use of ellipses (...) (<code>"unnecessaryEllipses"</code>).</li>
+          <li><strong>The Oxford comma:</strong> Suggestions for adding the Oxford comma after the second-to-last item in a list of things. (<code>"oxfordComma"</code>).</li>
+          <li><strong>The passive voice:</strong> Suggestions regarding use of the passive voice (<code>"passiveVoice"</code>).</li>
+          <li><strong>Stylistic fragments:</strong> Suggestions for completing all incomplete sentences, including stylistic sentence fragments that may be intentional (<code>"stylisticFragments"</code>).</li>
           <li><strong>Conjunctions at the start of a sentence:</strong> Suggestions for using conjunctions such as "but" and "and" at the beginning of sentences (<code>"conjunctionAtStartOfSentence"</code>).</li>
           <li><strong>Prepositions at the end of a sentence:</strong> Suggestions for using prepositions such as "with" and "in" at the end of sentences (<code>"prepositionAtTheEndOfSentence"</code>).</li>
           <li><strong>Informal academic pronouns:</strong> Suggestions for using personal pronouns such as "I" and "you" in academic writing (<code>"informalPronounsAcademic"</code>).</li>
-          <li><strong>The Oxford comma:</strong> Suggestions for adding the Oxford comma after the second-to-last item in a list of things. (<code>"oxfordComma"</code>).</li>
-          <li><strong>The passive voice:</strong> Suggestions regarding use of the passive voice (<code>"passiveVoice"</code>).</li>
-          <li><strong>Unnecessary ellipsis:</strong> Suggestions regarding unnecessary use of ellipses (...) (<code>"unnecessaryEllipses"</code>).</li>
-          <li><strong>Stylistic fragments:</strong> Suggestions for completing all incomplete sentences, including stylistic sentence fragments that may be intentional (<code>"stylisticFragments"</code>).</li>
         </ul>
     </p>
 

--- a/examples/editor-sdk-suggestions-config/public/index.html
+++ b/examples/editor-sdk-suggestions-config/public/index.html
@@ -40,7 +40,7 @@
         <li><a href="/suggestion-categories/stylistic-fragments.html">Stylistic fragments</a> (<code>"stylisticFragments"</code>)</li>
       </ul>
     </p>
-    <h2>Default settings for Suggestion Categories</h2>
+    <h2>Default settings for suggestion categories</h2>
     <p>
       By default, the Grammarly Text Editor SDK mutes (turns "off") seven categories of writing suggestions.
         <ul>

--- a/examples/editor-sdk-suggestions-config/public/index.html
+++ b/examples/editor-sdk-suggestions-config/public/index.html
@@ -12,22 +12,13 @@
   <body>
     <h2>Suggestion Categories (Default)</h2>
     <p>
-      By default, the Grammarly Text Editor SDK mutes (turns "off") seven categories of writing suggestions.
-        <ul>
-          <li><strong>Conjunctions at the start of a sentence:</strong> Suggestions for using conjunctions such as "but" and "and" at the beginning of sentences (<code>"conjunctionAtStartOfSentence"</code>).</li>
-          <li><strong>Prepositions at the end of a sentence:</strong> Suggestions for using prepositions such as "with" and "in" at the end of sentences (<code>"prepositionAtTheEndOfSentence"</code>).</li>
-          <li><strong>Informal academic pronouns:</strong> Suggestions for using personal pronouns such as "I" and "you" in academic writing (<code>"informalPronounsAcademic"</code>).</li>
-          <li><strong>The Oxford comma:</strong> Suggestions for adding the Oxford comma after the second-to-last item in a list of things. (<code>"oxfordComma"</code>).</li>
-          <li><strong>The passive voice:</strong> Suggestions regarding use of the passive voice (<code>"passiveVoice"</code>).</li>
-          <li><strong>Unnecessary Ellipsis:</strong> Suggestions regarding unnecessary use of ellipses (...) (<code>"unnecessaryEllipses"</code>).</li>
-          <li><strong>Stylistic fragments:</strong> Suggestions for completing all incomplete sentences, including stylistic sentence fragments that may be intentional (<code>"stylisticFragments"</code>).</li>
-        </ul>
+      When a writing suggestion category is set to "off", as is the case with the seven categories of suggestions that are muted with default settings, any suggestions belonging to that category will be muted (not visible to the user);
+      however, if a user has connected their Grammarly account to your application, the full set of customized suggestions from their user profile will always take precedence (overriding these configurations).
     </p>
     <p>
-      When a suggestion category is set to "off", as is the case with the above categories of suggestions with default settings, any suggestions belonging to that category will be muted (not visible to the user);
-      however, if a user has connected their Grammarly account to your application, the full set of customized suggestions from their user profile will always take precedence.
+      <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
     </p>
-    <grammarly-editor-plugin>
+    <grammarly-editor-plugin activation="immediate">
       <div contenteditable="true">
         <p>
           Please bring me a pencil, eraser and notebook.
@@ -35,7 +26,27 @@
       </div>
     </grammarly-editor-plugin>
     <p>
-      Configuring suggestion categories is available only on the Grammarly Text Editor SDK Plus plan.
+      Configuring and muting writing suggestion categories is available only on the Grammarly Text Editor SDK Plus plan.
+    </p>
+    <p>
+      By default, the Grammarly Text Editor SDK mutes (turns "off") seven categories of writing suggestions.
+        <ul>
+          <li><strong>Conjunctions at the start of a sentence:</strong> Suggestions for using conjunctions such as "but" and "and" at the beginning of sentences (<code>"conjunctionAtStartOfSentence"</code>).</li>
+          <li><strong>Prepositions at the end of a sentence:</strong> Suggestions for using prepositions such as "with" and "in" at the end of sentences (<code>"prepositionAtTheEndOfSentence"</code>).</li>
+          <li><strong>Informal academic pronouns:</strong> Suggestions for using personal pronouns such as "I" and "you" in academic writing (<code>"informalPronounsAcademic"</code>).</li>
+          <li><strong>The Oxford comma:</strong> Suggestions for adding the Oxford comma after the second-to-last item in a list of things. (<code>"oxfordComma"</code>).</li>
+          <li><strong>The passive voice:</strong> Suggestions regarding use of the passive voice (<code>"passiveVoice"</code>).</li>
+          <li><strong>Unnecessary ellipsis:</strong> Suggestions regarding unnecessary use of ellipses (...) (<code>"unnecessaryEllipses"</code>).</li>
+          <li><strong>Stylistic fragments:</strong> Suggestions for completing all incomplete sentences, including stylistic sentence fragments that may be intentional (<code>"stylisticFragments"</code>).</li>
+        </ul>
+    </p>
+
+    <p>
+      Explore these other pages to try configurations that mute different suggestion categories:
+      <ul>
+        <li><a href="/suggestion-categories/oxford-comma.html">The Oxford comma</a> (<code>"oxfordComma"</code>)
+        <li><a href="/suggestion-categories/passive-voice.html">Passive voice</a> (<code>"passiveVoice"</code>)
+        <li><a href="/suggestion-categories/stylistic-fragments.html">Stylistic fragments</a> (<code>"stylisticFragments"</code>)
     </p>
 
       <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.5?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>

--- a/examples/editor-sdk-suggestions-config/public/index.html
+++ b/examples/editor-sdk-suggestions-config/public/index.html
@@ -40,7 +40,7 @@
     <h2>Default settings for Suggestion Categories</h2>
     <p>
       By default, the Grammarly Text Editor SDK mutes (turns "off") seven categories of writing suggestions.
-        <ul>
+        <ul style="padding-bottom: 50px;"> <!--Padding used to add space between final list item text and Grammarly button-->
           <li><strong>Unnecessary ellipsis:</strong> Suggestions regarding unnecessary use of ellipses (...) (<code>"unnecessaryEllipses"</code>).</li>
           <li><strong>The Oxford comma:</strong> Suggestions for adding the Oxford comma after the second-to-last item in a list of things. (<code>"oxfordComma"</code>).</li>
           <li><strong>The passive voice:</strong> Suggestions regarding use of the passive voice (<code>"passiveVoice"</code>).</li>
@@ -50,7 +50,6 @@
           <li><strong>Informal academic pronouns:</strong> Suggestions for using personal pronouns such as "I" and "you" in academic writing (<code>"informalPronounsAcademic"</code>).</li>
         </ul>
     </p>
-
       <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.5?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-suggestions-config/public/index.html
+++ b/examples/editor-sdk-suggestions-config/public/index.html
@@ -30,7 +30,7 @@
       Configuring and muting writing suggestion categories is available only on the Grammarly Text Editor SDK Plus plan.
     </p>
     <p>
-      Explore these other pages to try configurations that mute different suggestion categories:
+      Explore these other pages to try configurations that turn on different categories of writing suggestions:
       <ul>
         <li><a href="/suggestion-categories/oxford-comma.html">The Oxford comma</a> (<code>"oxfordComma"</code>)</li>
         <li><a href="/suggestion-categories/passive-voice.html">Passive voice</a> (<code>"passiveVoice"</code>)</li>

--- a/examples/editor-sdk-suggestions-config/public/index.html
+++ b/examples/editor-sdk-suggestions-config/public/index.html
@@ -6,20 +6,20 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <title>Demo App</title>
+    <title>Suggestion Categories demo</title>
     <link rel="stylesheet" href="/style.css">
   </head>
   <body>
     <h2>Suggestion Categories (Default)</h2>
     <p>
-      When a writing suggestion category is set to "off", as is the case with the seven categories of suggestions that are muted with default settings, any suggestions belonging to that category will be muted (not visible to the user);
-      when a writing suggestion category is set to "on", any suggestions belonging to that category will be surfaced (visible to the user in suggestion underlines).
+      Suggestion categories determine the type of stylistic suggestions that are visible ("on") or muted/not visible ("off") in the Grammarly Text Editor Plugin. 
+      If your app is on the Plus plan, you can configure which suggestion categories are on or off in the plugin. 
     </p>
     <p>
       Note that if a user has connected their Grammarly account to your application, the full set of customized suggestions from their user profile will always take precedence (overriding these configurations).
     </p>
     <p>
-      <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
+      <strong>Try the Grammarly Text Editor Plugin in the text area below!</strong>
       <p>In this example, writing suggestions for unnecessary ellipsis are turned "on".</p>
     </p>
     <grammarly-editor-plugin config.activation="immediate" config.suggestionCategories.unnecessaryEllipses="on">
@@ -30,9 +30,6 @@
       </div>
     </grammarly-editor-plugin>
     <p>
-      Configuring and muting writing suggestion categories is available only on the Grammarly Text Editor SDK Plus plan.
-    </p>
-    <p>
       Explore these other pages to try configurations that turn on different categories of writing suggestions:
       <ul>
         <li><a href="/suggestion-categories/oxford-comma.html">The Oxford comma</a> (<code>"oxfordComma"</code>)</li>
@@ -40,7 +37,7 @@
         <li><a href="/suggestion-categories/stylistic-fragments.html">Stylistic fragments</a> (<code>"stylisticFragments"</code>)</li>
       </ul>
     </p>
-    <h2>Default settings for suggestion categories</h2>
+    <h2>Default settings for Suggestion Categories</h2>
     <p>
       By default, the Grammarly Text Editor SDK mutes (turns "off") seven categories of writing suggestions.
         <ul>

--- a/examples/editor-sdk-suggestions-config/public/index.html
+++ b/examples/editor-sdk-suggestions-config/public/index.html
@@ -32,9 +32,10 @@
     <p>
       Explore these other pages to try configurations that mute different suggestion categories:
       <ul>
-        <li><a href="/suggestion-categories/oxford-comma.html">The Oxford comma</a> (<code>"oxfordComma"</code>)
-        <li><a href="/suggestion-categories/passive-voice.html">Passive voice</a> (<code>"passiveVoice"</code>)
-        <li><a href="/suggestion-categories/stylistic-fragments.html">Stylistic fragments</a> (<code>"stylisticFragments"</code>)
+        <li><a href="/suggestion-categories/oxford-comma.html">The Oxford comma</a> (<code>"oxfordComma"</code>)</li>
+        <li><a href="/suggestion-categories/passive-voice.html">Passive voice</a> (<code>"passiveVoice"</code>)</li>
+        <li><a href="/suggestion-categories/stylistic-fragments.html">Stylistic fragments</a> (<code>"stylisticFragments"</code>)</li>
+      </ul>
     </p>
     <p>
       By default, the Grammarly Text Editor SDK mutes (turns "off") seven categories of writing suggestions.

--- a/examples/editor-sdk-suggestions-config/public/index.html
+++ b/examples/editor-sdk-suggestions-config/public/index.html
@@ -13,7 +13,10 @@
     <h2>Suggestion Categories (Default)</h2>
     <p>
       When a writing suggestion category is set to "off", as is the case with the seven categories of suggestions that are muted with default settings, any suggestions belonging to that category will be muted (not visible to the user);
-      however, if a user has connected their Grammarly account to your application, the full set of customized suggestions from their user profile will always take precedence (overriding these configurations).
+      when a writing suggestion category is set to "on", any suggestions belonging to that category will be surfaced (visible to the user in suggestion underlines).
+    </p>
+    <p>
+      Note that if a user has connected their Grammarly account to your application, the full set of customized suggestions from their user profile will always take precedence (overriding these configurations).
     </p>
     <p>
       <strong>Try the Grammarly Editor Plugin in the text area below!</strong>

--- a/examples/editor-sdk-suggestions-config/public/index.html
+++ b/examples/editor-sdk-suggestions-config/public/index.html
@@ -37,6 +37,7 @@
         <li><a href="/suggestion-categories/stylistic-fragments.html">Stylistic fragments</a> (<code>"stylisticFragments"</code>)</li>
       </ul>
     </p>
+    <h2>Default settings for Suggestion Categories</h2>
     <p>
       By default, the Grammarly Text Editor SDK mutes (turns "off") seven categories of writing suggestions.
         <ul>

--- a/examples/editor-sdk-suggestions-config/public/index.html
+++ b/examples/editor-sdk-suggestions-config/public/index.html
@@ -17,11 +17,12 @@
     </p>
     <p>
       <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
+      <p>In this example, writing suggestions for unnecessary ellipsis are turned "on".</p>
     </p>
-    <grammarly-editor-plugin activation="immediate">
+    <grammarly-editor-plugin activation="immediate" config.suggestionCategories.unnecessaryEllipses="on">
       <div contenteditable="true">
         <p>
-          Please bring me a pencil, eraser and notebook.
+          Please bring me a pencil, eraser and notebook...
         </p>
       </div>
     </grammarly-editor-plugin>

--- a/examples/editor-sdk-suggestions-config/public/index.html
+++ b/examples/editor-sdk-suggestions-config/public/index.html
@@ -30,6 +30,13 @@
       Configuring and muting writing suggestion categories is available only on the Grammarly Text Editor SDK Plus plan.
     </p>
     <p>
+      Explore these other pages to try configurations that mute different suggestion categories:
+      <ul>
+        <li><a href="/suggestion-categories/oxford-comma.html">The Oxford comma</a> (<code>"oxfordComma"</code>)
+        <li><a href="/suggestion-categories/passive-voice.html">Passive voice</a> (<code>"passiveVoice"</code>)
+        <li><a href="/suggestion-categories/stylistic-fragments.html">Stylistic fragments</a> (<code>"stylisticFragments"</code>)
+    </p>
+    <p>
       By default, the Grammarly Text Editor SDK mutes (turns "off") seven categories of writing suggestions.
         <ul>
           <li><strong>Conjunctions at the start of a sentence:</strong> Suggestions for using conjunctions such as "but" and "and" at the beginning of sentences (<code>"conjunctionAtStartOfSentence"</code>).</li>
@@ -40,14 +47,6 @@
           <li><strong>Unnecessary ellipsis:</strong> Suggestions regarding unnecessary use of ellipses (...) (<code>"unnecessaryEllipses"</code>).</li>
           <li><strong>Stylistic fragments:</strong> Suggestions for completing all incomplete sentences, including stylistic sentence fragments that may be intentional (<code>"stylisticFragments"</code>).</li>
         </ul>
-    </p>
-
-    <p>
-      Explore these other pages to try configurations that mute different suggestion categories:
-      <ul>
-        <li><a href="/suggestion-categories/oxford-comma.html">The Oxford comma</a> (<code>"oxfordComma"</code>)
-        <li><a href="/suggestion-categories/passive-voice.html">Passive voice</a> (<code>"passiveVoice"</code>)
-        <li><a href="/suggestion-categories/stylistic-fragments.html">Stylistic fragments</a> (<code>"stylisticFragments"</code>)
     </p>
 
       <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.5?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>

--- a/examples/editor-sdk-suggestions-config/public/style.css
+++ b/examples/editor-sdk-suggestions-config/public/style.css
@@ -1,0 +1,34 @@
+<style>
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: sans-serif;
+}
+
+ul li {
+  line-height: 1.5em;
+}
+
+input,
+textarea,
+[contenteditable] {
+  font: inherit;
+  line-height: 1.5;
+  width: 600px;
+  padding: 8px 12px;
+  overflow: auto;
+}
+
+label {
+  display: block;
+  margin-bottom: 4px;
+}
+
+[contenteditable] {
+  height: 10rem;
+  border: 1px solid;
+  resize: both;
+}
+</style>

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/oxford-comma.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/oxford-comma.html
@@ -13,8 +13,9 @@
     <h2>Suggestion Categories (Suggestions for the Oxford comma turned "on")</h2>
     <p>
       The Grammarly Editor Plugin on this page is set to mute suggestions for the
-      <code>"oxfordComma"</code> writing suggestion category. This category suggests 
-      adding the Oxford comma after the second-to-last item in a list of things.
+      <code>"oxfordComma"</code> writing suggestion category.
+      
+      This category suggests adding the Oxford comma after the second-to-last item in a list of things.
     </p>
     <p>
       <strong>Try the Grammarly Editor Plugin in the text area below!</strong>

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/oxford-comma.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/oxford-comma.html
@@ -15,7 +15,8 @@
       The Grammarly Editor Plugin on this page is set to mute suggestions for the
       <code>"oxfordComma"</code> writing suggestion category.
       
-      This category suggests adding the Oxford comma after the second-to-last item in a list of things.
+      This category suggests adding the Oxford comma after the second-to-last item in a list of things. 
+      Note that some dialects, like Australian English, may recommend usage of the Oxford comma more sparingly.
     </p>
     <p>
       <strong>Try the Grammarly Editor Plugin in the text area below!</strong>

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/oxford-comma.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/oxford-comma.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="/style.css">
   </head>
   <body>
-    <h2>Suggestion Categories (Suggestions for the Oxford comma turned "on")</h2>
+    <h2>Suggestion Categories (Oxford comma turned "on")</h2>
     <p>
       The Grammarly Editor Plugin on this page is set to mute suggestions for the
       <code>"oxfordComma"</code> writing suggestion category.

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/oxford-comma.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/oxford-comma.html
@@ -6,13 +6,13 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <title>Demo App</title>
+    <title>Suggestion Categories demo</title>
     <link rel="stylesheet" href="/style.css">
   </head>
   <body>
     <h2>Suggestion categories (Oxford comma turned "on")</h2>
     <p>
-      The Grammarly Editor Plugin on this page is set to mute suggestions for the
+      The Grammarly Text Editor Plugin on this page is set to show suggestions for the
       <code>"oxfordComma"</code> writing suggestion category.
       
       This category, which is muted by default, suggests adding the Oxford comma after the second-to-last item in a list of things. 

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/oxford-comma.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/oxford-comma.html
@@ -20,6 +20,7 @@
     </p>
     <p>
       <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
+      <p>In this example, writing suggestions for adding the Oxford comma are turned "on".</p>
     </p>
     <grammarly-editor-plugin config.activation="immediate" config.suggestionCategories.oxfordComma="on">
       <div contenteditable="true">

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/oxford-comma.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/oxford-comma.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <title>Demo App</title>
+    <link rel="stylesheet" href="/style.css">
+  </head>
+  <body>
+    <h2>Suggestion Categories (Oxford Comma)</h2>
+
+    <grammarly-editor-plugin config.activation="immediate" config.suggestionCategories.oxfordComma="on">
+      <div contenteditable="true">
+        <p>
+          Please bring me a pencil, eraser and notebook.
+        </p>
+      </div>
+    </grammarly-editor-plugin>
+
+    <script src="https://unpkg.com/@grammarly/editor-sdk@2.3.5?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+  </body>
+</html>

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/oxford-comma.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/oxford-comma.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="/style.css">
   </head>
   <body>
-    <h2>Suggestion Categories (Oxford comma turned "on")</h2>
+    <h2>Suggestion categories (Oxford comma turned "on")</h2>
     <p>
       The Grammarly Editor Plugin on this page is set to mute suggestions for the
       <code>"oxfordComma"</code> writing suggestion category.
@@ -19,7 +19,7 @@
       Note that some dialects, like Australian English, may recommend usage of the Oxford comma more sparingly.
     </p>
     <p>
-      <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
+      <strong>Try the Grammarly Text Editor Plugin in the text area below!</strong>
       <p>In this example, writing suggestions for adding the Oxford comma are turned "on".</p>
     </p>
     <grammarly-editor-plugin config.activation="immediate" config.suggestionCategories.oxfordComma="on">

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/oxford-comma.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/oxford-comma.html
@@ -15,7 +15,7 @@
       The Grammarly Editor Plugin on this page is set to mute suggestions for the
       <code>"oxfordComma"</code> writing suggestion category.
       
-      This category suggests adding the Oxford comma after the second-to-last item in a list of things. 
+      This category, which is muted by default, suggests adding the Oxford comma after the second-to-last item in a list of things. 
       Note that some dialects, like Australian English, may recommend usage of the Oxford comma more sparingly.
     </p>
     <p>

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/passive-voice.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/passive-voice.html
@@ -13,8 +13,9 @@
     <h2>Suggestion Categories (Suggestions regarding use of the passive voice turned "on")</h2>
     <p>
       The Grammarly Editor Plugin on this page is set to mute suggestions for the
-      <code>"passiveVoice"</code> writing suggestion category. This category adds 
-      writing suggestions regarding the use of the passive voice.
+      <code>"passiveVoice"</code> writing suggestion category.
+      
+      This category adds writing suggestions regarding the use of the passive voice.
     </p>
     <p>
       <strong>Try the Grammarly Editor Plugin in the text area below!</strong>

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/passive-voice.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/passive-voice.html
@@ -10,19 +10,19 @@
     <link rel="stylesheet" href="/style.css">
   </head>
   <body>
-    <h2>Suggestion Categories (Suggestions for the Oxford comma turned "on")</h2>
+    <h2>Suggestion Categories (Suggestions regarding use of the passive voice turned "on")</h2>
     <p>
       The Grammarly Editor Plugin on this page is set to mute suggestions for the
-      <code>"oxfordComma"</code> writing suggestion category. This category suggests 
-      adding the Oxford comma after the second-to-last item in a list of things.
+      <code>"passiveVoice"</code> writing suggestion category. This category adds 
+      writing suggestions regarding the use of the passive voice.
     </p>
     <p>
       <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
     </p>
-    <grammarly-editor-plugin config.activation="immediate" config.suggestionCategories.oxfordComma="on">
+    <grammarly-editor-plugin config.activation="immediate" config.suggestionCategories.passiveVoice="on">
       <div contenteditable="true">
         <p>
-          Please bring me a pencil, eraser and notebook.
+          The example code was written by Andrew.
         </p>
       </div>
     </grammarly-editor-plugin>

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/passive-voice.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/passive-voice.html
@@ -19,6 +19,7 @@
     </p>
     <p>
       <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
+      <p>In this example, writing suggestions for avoiding the passive voice in favor of the active voice are turned "on".</p>
     </p>
     <grammarly-editor-plugin config.activation="immediate" config.suggestionCategories.passiveVoice="on">
       <div contenteditable="true">

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/passive-voice.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/passive-voice.html
@@ -6,13 +6,13 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <title>Demo App</title>
+    <title>Suggestion Categories demo</title>
     <link rel="stylesheet" href="/style.css">
   </head>
   <body>
     <h2>Suggestion categories (Passive voice suggestions turned "on")</h2>
     <p>
-      The Grammarly Editor Plugin on this page is set to mute suggestions for the
+      The Grammarly Text Editor Plugin on this page is set to show suggestions for the
       <code>"passiveVoice"</code> writing suggestion category.
       
       This category, which is muted by default, adds writing suggestions regarding the use of the passive voice.

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/passive-voice.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/passive-voice.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="/style.css">
   </head>
   <body>
-    <h2>Suggestion Categories (Suggestions regarding use of the passive voice turned "on")</h2>
+    <h2>Suggestion Categories (Passive voice suggestions turned "on")</h2>
     <p>
       The Grammarly Editor Plugin on this page is set to mute suggestions for the
       <code>"passiveVoice"</code> writing suggestion category.

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/passive-voice.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/passive-voice.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="/style.css">
   </head>
   <body>
-    <h2>Suggestion Categories (Passive voice suggestions turned "on")</h2>
+    <h2>Suggestion categories (Passive voice suggestions turned "on")</h2>
     <p>
       The Grammarly Editor Plugin on this page is set to mute suggestions for the
       <code>"passiveVoice"</code> writing suggestion category.
@@ -18,7 +18,7 @@
       This category, which is muted by default, adds writing suggestions regarding the use of the passive voice.
     </p>
     <p>
-      <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
+      <strong>Try the Grammarly Text Editor Plugin in the text area below!</strong>
       <p>In this example, writing suggestions for avoiding the passive voice in favor of the active voice are turned "on".</p>
     </p>
     <grammarly-editor-plugin config.activation="immediate" config.suggestionCategories.passiveVoice="on">

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/passive-voice.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/passive-voice.html
@@ -15,7 +15,7 @@
       The Grammarly Editor Plugin on this page is set to mute suggestions for the
       <code>"passiveVoice"</code> writing suggestion category.
       
-      This category adds writing suggestions regarding the use of the passive voice.
+      This category, which is muted by default, adds writing suggestions regarding the use of the passive voice.
     </p>
     <p>
       <strong>Try the Grammarly Editor Plugin in the text area below!</strong>

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/stylistic-fragments.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/stylistic-fragments.html
@@ -15,7 +15,7 @@
       The Grammarly Editor Plugin on this page is set to mute suggestions for the
       <code>"stylisticFragments"</code> writing suggestion category.
       
-      This category suggests completing all incomplete sentences, including stylistic sentence fragments that may 
+      This category, which is muted by default, suggests completing all incomplete sentences, including stylistic sentence fragments that may 
       be intentional.
     </p>
     <p>

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/stylistic-fragments.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/stylistic-fragments.html
@@ -6,20 +6,20 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <title>Demo App</title>
+    <title>Suggestion Categories demo</title>
     <link rel="stylesheet" href="/style.css">
   </head>
   <body>
     <h2>Suggestion Categories (Completing stylistic fragments turned "on")</h2>
     <p>
-      The Grammarly Text Editor Plugin on this page is set to mute suggestions for the
+      The Grammarly Text Editor Plugin on this page is set to show suggestions for the
       <code>"stylisticFragments"</code> writing suggestion category.
       
       This category, which is muted by default, suggests completing all incomplete sentences, including stylistic sentence fragments that may 
       be intentional.
     </p>
     <p>
-      <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
+      <strong>Try the Grammarly Text Editor Plugin in the text area below!</strong>
       <p>In this example, writing suggestions for completing sentence fragments are turned "on".</p>
     </p>
     <grammarly-editor-plugin config.activation="immediate" config.suggestionCategories.stylisticFragments="on">

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/stylistic-fragments.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/stylistic-fragments.html
@@ -10,19 +10,20 @@
     <link rel="stylesheet" href="/style.css">
   </head>
   <body>
-    <h2>Suggestion Categories (Suggestions for the Oxford comma turned "on")</h2>
+    <h2>Suggestion Categories (Suggestion for avoiding writing fragments turned "on")</h2>
     <p>
       The Grammarly Editor Plugin on this page is set to mute suggestions for the
-      <code>"oxfordComma"</code> writing suggestion category. This category suggests 
-      adding the Oxford comma after the second-to-last item in a list of things.
+      <code>"stylisticFragments"</code> writing suggestion category. This category suggests 
+      completing all incomplete sentences, including stylistic sentence fragments that may 
+      be intentional.
     </p>
     <p>
       <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
     </p>
-    <grammarly-editor-plugin config.activation="immediate" config.suggestionCategories.oxfordComma="on">
+    <grammarly-editor-plugin config.activation="immediate" config.suggestionCategories.stylisticFragments="on">
       <div contenteditable="true">
         <p>
-          Please bring me a pencil, eraser and notebook.
+          Because of the great code example.
         </p>
       </div>
     </grammarly-editor-plugin>

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/stylistic-fragments.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/stylistic-fragments.html
@@ -13,8 +13,9 @@
     <h2>Suggestion Categories (Suggestion for avoiding writing fragments turned "on")</h2>
     <p>
       The Grammarly Editor Plugin on this page is set to mute suggestions for the
-      <code>"stylisticFragments"</code> writing suggestion category. This category suggests 
-      completing all incomplete sentences, including stylistic sentence fragments that may 
+      <code>"stylisticFragments"</code> writing suggestion category.
+      
+      This category suggests completing all incomplete sentences, including stylistic sentence fragments that may 
       be intentional.
     </p>
     <p>

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/stylistic-fragments.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/stylistic-fragments.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="/style.css">
   </head>
   <body>
-    <h2>Suggestion Categories (Suggestion for avoiding writing fragments turned "on")</h2>
+    <h2>Suggestion Categories (Completing stylistic fragments turned "on")</h2>
     <p>
       The Grammarly Editor Plugin on this page is set to mute suggestions for the
       <code>"stylisticFragments"</code> writing suggestion category.

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/stylistic-fragments.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/stylistic-fragments.html
@@ -20,6 +20,7 @@
     </p>
     <p>
       <strong>Try the Grammarly Editor Plugin in the text area below!</strong>
+      <p>In this example, writing suggestions for completing sentence fragments are turned "on".</p>
     </p>
     <grammarly-editor-plugin config.activation="immediate" config.suggestionCategories.stylisticFragments="on">
       <div contenteditable="true">

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/stylistic-fragments.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/stylistic-fragments.html
@@ -12,7 +12,7 @@
   <body>
     <h2>Suggestion Categories (Completing stylistic fragments turned "on")</h2>
     <p>
-      The Grammarly Editor Plugin on this page is set to mute suggestions for the
+      The Grammarly Text Editor Plugin on this page is set to mute suggestions for the
       <code>"stylisticFragments"</code> writing suggestion category.
       
       This category, which is muted by default, suggests completing all incomplete sentences, including stylistic sentence fragments that may 

--- a/examples/editor-sdk-suggestions-config/readme.md
+++ b/examples/editor-sdk-suggestions-config/readme.md
@@ -10,7 +10,7 @@ You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/
 
 [index.html](./public/index.html) and the other HTML files in this repository contain `<div contenteditable>` elements. These elements are wrapped with the `<grammarly-editor-plugin>` web component so that Grammarly suggestions will be displayed in the specified text areas. 
 
-HTML attributes on `<grammarly-editor-plugin>` toward the bottom of the file configure the Grammarly Text Editor SDK. See [index.html](./public/index.html) for the full code example.
+HTML attributes on `<grammarly-editor-plugin>` toward the bottom of the file configure the plugin. See [index.html](./public/index.html) for the full code example.
 
 ## Get the code
 

--- a/examples/editor-sdk-suggestions-config/readme.md
+++ b/examples/editor-sdk-suggestions-config/readme.md
@@ -8,7 +8,7 @@ You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/
 
 ## How it works
 
-[index.html](./public/index.html) and the other HTML files in this repository contain `<div contenteditable>` elements. These elements are wrapped with the `<grammarly-editor-plugin>` web component so that Grammarly suggestions will be displayed in the specified text areas. 
+[index.html](./public/index.html) and the other HTML files in this repository contain `<div contenteditable>` elements. These elements are wrapped with the `<grammarly-editor-plugin>` web component so that Grammarly's writing suggestions are displayed within the `contenteditable` text areas. 
 
 HTML attributes on `<grammarly-editor-plugin>` toward the bottom of the file configure the plugin. See [index.html](./public/index.html) for the full code example.
 

--- a/examples/editor-sdk-suggestions-config/readme.md
+++ b/examples/editor-sdk-suggestions-config/readme.md
@@ -1,6 +1,6 @@
 # Grammarly Text Editor SDK with suggestions config
 
-This demo shows how to mute categories of [suggestions](https://developer.grammarly.com/docs/api/editor-sdk/editorconfig#suggestions) in the [Grammarly Text Editor SDK](https://developer.grammarly.com/).
+This demo shows how to [mute categories of writing suggestions](https://developer.grammarly.com/docs/api/editor-sdk/editorconfig#suggestions) in the [Grammarly Text Editor SDK](https://developer.grammarly.com/).
 
 ## Try the demo
 

--- a/examples/editor-sdk-suggestions-config/readme.md
+++ b/examples/editor-sdk-suggestions-config/readme.md
@@ -1,6 +1,6 @@
 # Grammarly Text Editor SDK with suggestions config
 
-This demo shows how to add [suggestions](https://developer.grammarly.com/docs/api/editor-sdk/editorconfig#suggestions) config to  [Grammarly Text Editor SDK](https://developer.grammarly.com/).
+This demo shows how to mute categories of [suggestions](https://developer.grammarly.com/docs/api/editor-sdk/editorconfig#suggestions) in the [Grammarly Text Editor SDK](https://developer.grammarly.com/).
 
 ## Try the demo
 
@@ -8,7 +8,9 @@ You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/
 
 ## How it works
 
-[index.html](./public/index.html) contains `<div contenteditable>` elements. These elements are wrapped with the `<grammarly-editor-plugin>` tag so that Grammarly suggestions will be displayed in them. JavaScript code toward the bottom of the file configures the Grammarly Text Editor SDK. See [index.html](./public/index.html) for the full code example.
+[index.html](./public/index.html) and the other HTML files in this repository contain `<div contenteditable>` elements. These elements are wrapped with the `<grammarly-editor-plugin>` web component so that Grammarly suggestions will be displayed in the specified text areas. 
+
+HTML attributes on `<grammarly-editor-plugin>` toward the bottom of the file configure the Grammarly Text Editor SDK. See [index.html](./public/index.html) for the full code example.
 
 ## Get the code
 

--- a/examples/editor-sdk-suggestions-config/readme.md
+++ b/examples/editor-sdk-suggestions-config/readme.md
@@ -1,6 +1,6 @@
-# Grammarly Text Editor SDK with suggestions config
+# Grammarly Text Editor SDK with suggestionCategories
 
-This demo shows how to [mute categories of writing suggestions](https://developer.grammarly.com/docs/api/editor-sdk/editorconfig#suggestions) in the [Grammarly Text Editor SDK](https://developer.grammarly.com/).
+This demo shows how to turn on [categories of writing suggestions](https://developer.grammarly.com/docs/api/editor-sdk/editorconfig#suggestions) in the [Grammarly Text Editor SDK](https://developer.grammarly.com/).
 
 ## Try the demo
 


### PR DESCRIPTION
Similar goals to https://github.com/grammarly/grammarly-for-developers/pull/395.

To test, create a codesandbox from https://github.com/AndrewDiMola/grammarly-for-developers/tree/refactor-suggestion-categories-examples/examples/editor-sdk-suggestions-config.

(https://codesandbox.io/s/github/andrewdimola/grammarly-for-developers/tree/refactor-suggestion-categories-examples/examples/editor-sdk-suggestions-config?file=/public/index.html)