### PR TITLE
Add Editor.js example

### DIFF
--- a/examples/editor-sdk-editorjs/package.json
+++ b/examples/editor-sdk-editorjs/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "grammarly-example-editor-sdk-editorjs",
+  "version": "1.0.2",
+  "description": "Example that uses @grammarly/editor-sdk with Editor.js",
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "3.8.3"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  }
+}

--- a/examples/editor-sdk-editorjs/public/index.html
+++ b/examples/editor-sdk-editorjs/public/index.html
@@ -44,8 +44,6 @@
       }
     </style>
   </head>
-  <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet" />
-
   <body>
     <h2>Editor.js Rich Text Editor</h2>
     <div id="editorjs"></div>

--- a/examples/editor-sdk-editorjs/public/index.html
+++ b/examples/editor-sdk-editorjs/public/index.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <title>Demo App</title>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        font-family: sans-serif;
+      }
+
+      h2 {
+        text-align: center;
+      }
+
+      input,
+      textarea,
+      [contenteditable] {
+        font: inherit;
+        line-height: 1.5;
+        padding: 8px 12px;
+      }
+
+      label {
+        display: block;
+        margin-bottom: 4px;
+      }
+
+      [contenteditable] {
+        height: 10rem;
+        max-height: 10rem;
+        border: 1px solid;
+        resize: both;
+        margin-bottom: 8px;
+        padding: 8px;
+        overflow-y: scroll;
+      }
+    </style>
+  </head>
+  <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet" />
+
+  <body>
+    <h2>EditorJS Rich Text Editor</h2>
+    <div id="editorjs"></div>
+
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest"></script>
+
+    <script>
+      (async () => {
+        grammarly = await Grammarly.init("client_9m1fYK3MPQxwKsib5CxtpB");
+
+        const addGrammarly = (htmlElement) => {
+          grammarly.addPlugin(htmlElement, { activation: "immediate" });
+        };
+        // Initialize an empty EditorJS editor
+        const editor = new EditorJS({
+          holder: "editorjs",
+          autofocus: true,
+          data: {
+            blocks: [
+              {
+                type: "paragraph",
+                data: {
+                  text:
+                    "Mispellings and grammatical errors can effect your credibility. The same goes for misused commas, and other types of punctuation . Not only will Grammarly underline these issues in red, it will also showed you how to correctly write the sentence."
+                }
+              },
+              {
+                type: "paragraph",
+                data: {
+                  text:
+                    "Underlines that are blue indicate that Grammarly has spotted a sentence that is unnecessarily wordy. You'll find suggestions that can possibly help you revise a wordy sentence in an effortless manner."
+                }
+              },
+              {
+                type: "paragraph",
+                data: {
+                  text:
+                    "But wait...there's more? Grammarly can give you very helpful feedback on your writing. Passive voice can be fixed by Grammarly, and it can handle classical word-choice mistakes. It can even help when you wanna refine ur slang or formality level. That's especially useful when writing for a broad audience ranging from businessmen to friends and family, don't you think? It'll inspect your vocabulary carefully and suggest the best word to make sure you don't have to analyze your writing too much."
+                }
+              }
+            ]
+          },
+          onReady: () => {
+            const initialEditor = document.querySelector("#editorjs");
+            editableDivs = initialEditor.querySelectorAll("[contenteditable]");
+            editableDivs.forEach((editable) => {
+              addGrammarly(editable);
+            });
+          },
+          onChange: (api, event) => {
+            const type = event.type;
+            if (type === "block-added") {
+              // Get block's contenteditable div
+              const detail = event.detail.target.holder;
+              editableDiv = detail.querySelector("[contenteditable]");
+              addGrammarly(editableDiv);
+            }
+          }
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/examples/editor-sdk-editorjs/public/index.html
+++ b/examples/editor-sdk-editorjs/public/index.html
@@ -47,23 +47,23 @@
   <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet" />
 
   <body>
-    <h2>EditorJS Rich Text Editor</h2>
+    <h2>Editor.js Rich Text Editor</h2>
     <div id="editorjs"></div>
 
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18"></script>
     <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest"></script>
 
     <script>
       (async () => {
-        grammarly = await Grammarly.init("client_9m1fYK3MPQxwKsib5CxtpB");
+        const grammarly = await Grammarly.init("client_9m1fYK3MPQxwKsib5CxtpB");
 
-        const addGrammarly = (htmlElement) => {
-          grammarly.addPlugin(htmlElement, { activation: "immediate" });
+        const config = {
+          activation: "immediate"
         };
+
         // Initialize an empty EditorJS editor
         const editor = new EditorJS({
           holder: "editorjs",
-          autofocus: true,
           data: {
             blocks: [
               {
@@ -93,16 +93,15 @@
             const initialEditor = document.querySelector("#editorjs");
             editableDivs = initialEditor.querySelectorAll("[contenteditable]");
             editableDivs.forEach((editable) => {
-              addGrammarly(editable);
+              grammarly.addPlugin(editable, config);
             });
           },
           onChange: (api, event) => {
             const type = event.type;
             if (type === "block-added") {
-              // Get block's contenteditable div
               const detail = event.detail.target.holder;
               editableDiv = detail.querySelector("[contenteditable]");
-              addGrammarly(editableDiv);
+              grammarly.addPlugin(editableDiv, config);
             }
           }
         });

--- a/examples/editor-sdk-editorjs/readme.md
+++ b/examples/editor-sdk-editorjs/readme.md
@@ -1,0 +1,21 @@
+# Grammarly Text Editor SDK & Editor.js Example
+
+This demo shows how to add the [Grammarly Text Editor SDK](https://developer.grammarly.com/) to a [Editor.js](https://editorjs.io/) rich text editor. The example uses [addPlugin()](https://developer.grammarly.com/docs/api/editor-sdk/editorsdk#addplugin) to add Grammarly suggestions in an imperative way.
+
+## Try the demo
+
+You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-editorjs?file=/public/index.html).
+
+## How it works
+
+[index.html](./public/index.html) contains a `<div>`. JavaScript code toward the bottom of the file initializes the Editor.js text editor on that `<div>` and also adds Grammarly suggestions to that `<div>`. See [index.html](./public/index.html) for the full code example.
+
+Learn more about how to add Grammarly suggestions to rich text editors by visiting the [Grammarly for Developers documentation](https://developer.grammarly.com/docs/#supported-text-editors).
+
+## Get the code
+
+A copy of this code is available in the [Grammarly for Developers GitHub repo](https://github.com/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-editorjs).
+
+## Ask a question
+
+If you want to ask a question, share a suggestion, or chat about how you're using the Grammarly Text Editor SDK in your application, join us in the [Grammarly for Developers Discussions](https://github.com/grammarly/grammarly-for-developers/discussions).

--- a/examples/editor-sdk-editorjs/readme.md
+++ b/examples/editor-sdk-editorjs/readme.md
@@ -8,7 +8,7 @@ You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/
 
 ## How it works
 
-[index.html](./public/index.html) contains a `<div>`. JavaScript code toward the bottom of the file initializes the Editor.js text editor on that `<div>` and also adds Grammarly suggestions to that `<div>`. See [index.html](./public/index.html) for the full code example.
+[index.html](./public/index.html) contains a `<div>`. JavaScript code toward the bottom of the file initializes the Editor.js text editor on that `<div>` and also adds Grammarly suggestions to that `<div>`. Check out [index.html](./public/index.html) for the full code example.
 
 Learn more about how to add Grammarly suggestions to rich text editors by visiting the [Grammarly for Developers documentation](https://developer.grammarly.com/docs/#supported-text-editors).
 

--- a/examples/readme.md
+++ b/examples/readme.md
@@ -95,6 +95,8 @@ These apps show how you can add the Text Editor Plugin to various rich text edit
 - **Quill:**
   - [JavaScript Example App](./editor-sdk-quill/)
   - [JavaScript Example App (Imperative)](./editor-sdk-quill-imperative/)
+- **Editor.js:**
+  - [Editor.js Example App](./editor-sdk-editorjs/)
 - **Slate:**
   - [React JavaScript Example App](./editor-sdk-react-slate/)
 - **TinyMCE:**


### PR DESCRIPTION
Add an official example of using Editor.js. Editor.js creates individual nested `contenteditable`s, so this example uses the imperative approach.