### PR TITLE
Update code examples to SDK version 2.4.0

### DIFF
--- a/examples/editor-sdk-activation/public/activationFocus.html
+++ b/examples/editor-sdk-activation/public/activationFocus.html
@@ -50,6 +50,6 @@ This paragraph has eight words and one mispeling.
           event.detail.suggestionsAccepted.total;
       }
     </script>
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-activation/public/index.html
+++ b/examples/editor-sdk-activation/public/index.html
@@ -50,6 +50,6 @@ This paragraph has eight words and one mispeling.
           event.detail.suggestionsAccepted.total;
       }
     </script>
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-angular/package.json
+++ b/examples/editor-sdk-angular/package.json
@@ -19,7 +19,7 @@
     "@angular/platform-browser": "^15.2.0",
     "@angular/platform-browser-dynamic": "^15.2.0",
     "@angular/router": "^15.2.0",
-    "@grammarly/editor-sdk": "^2.3.18",
+    "@grammarly/editor-sdk": "^2.4.0",
     "core-js": "^3.29.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/examples/editor-sdk-autocomplete/public/index.html
+++ b/examples/editor-sdk-autocomplete/public/index.html
@@ -70,6 +70,6 @@ Would any of </textarea>
       </grammarly-editor-plugin>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-ckeditor-imperative/public/index.html
+++ b/examples/editor-sdk-ckeditor-imperative/public/index.html
@@ -49,7 +49,7 @@
   </div>
 
   <script src="https://cdn.ckeditor.com/ckeditor5/34.0.0/classic/ckeditor.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   <script type="module">
 
     // Create a classic editor instance

--- a/examples/editor-sdk-ckeditor/public/index.html
+++ b/examples/editor-sdk-ckeditor/public/index.html
@@ -65,7 +65,7 @@
 
   </script>
 
-  <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
 </body>
 
 </html>

--- a/examples/editor-sdk-document-dialect/public/dialects/american-english.html
+++ b/examples/editor-sdk-document-dialect/public/dialects/american-english.html
@@ -36,6 +36,6 @@
       <a href="/index.html">Return to the index.</a>
     </p>
 
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-document-dialect/public/dialects/australian-english.html
+++ b/examples/editor-sdk-document-dialect/public/dialects/australian-english.html
@@ -36,6 +36,6 @@
       <a href="/index.html">Click here to return to the index.</a>
     </p>
 
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-document-dialect/public/dialects/british-english.html
+++ b/examples/editor-sdk-document-dialect/public/dialects/british-english.html
@@ -36,6 +36,6 @@
       <a href="/index.html">Click here to return to the index.</a>
     </p>
 
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-document-dialect/public/dialects/canadian-english.html
+++ b/examples/editor-sdk-document-dialect/public/dialects/canadian-english.html
@@ -36,6 +36,6 @@
       <a href="/index.html">Click here to return to the index.</a>
     </p>
 
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-document-dialect/public/dialects/indian-english.html
+++ b/examples/editor-sdk-document-dialect/public/dialects/indian-english.html
@@ -36,6 +36,6 @@
       <a href="/index.html">Return to the index.</a>
     </p>
 
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-document-dialect/public/index.html
+++ b/examples/editor-sdk-document-dialect/public/index.html
@@ -47,6 +47,6 @@
       </ul>
     </p>
 
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-document-domain/public/domains/academic-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/academic-domain.html
@@ -33,6 +33,6 @@
       <a href="/index.html">Return to the index.</a>
     </p>
 
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-document-domain/public/domains/business-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/business-domain.html
@@ -33,6 +33,6 @@
       <a href="/index.html">Return to the index.</a>
     </p>
 
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-document-domain/public/domains/casual-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/casual-domain.html
@@ -33,6 +33,6 @@
       <a href="/index.html">Return to the index.</a>
     </p>
 
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-document-domain/public/domains/creative-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/creative-domain.html
@@ -33,6 +33,6 @@
       <a href="/index.html">Return to the index.</a>
     </p>
 
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-document-domain/public/domains/mail-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/mail-domain.html
@@ -33,6 +33,6 @@
       <a href="/index.html">Return to the index.</a>
     </p>
 
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-document-domain/public/index.html
+++ b/examples/editor-sdk-document-domain/public/index.html
@@ -45,6 +45,6 @@
       </ul>
     </p>
 
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-editorjs/public/index.html
+++ b/examples/editor-sdk-editorjs/public/index.html
@@ -48,7 +48,7 @@
     <h2>Editor.js Rich Text Editor</h2>
     <div id="editorjs"></div>
 
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0"></script>
     <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest"></script>
 
     <script>

--- a/examples/editor-sdk-events/public/index.html
+++ b/examples/editor-sdk-events/public/index.html
@@ -66,7 +66,7 @@
       <h3>Events History:</h3>
       <p id="events-information">No Event</p>
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
     <script>
       const editor = document.querySelector("grammarly-editor-plugin")
 

--- a/examples/editor-sdk-intro-text/public/index.html
+++ b/examples/editor-sdk-intro-text/public/index.html
@@ -55,7 +55,7 @@
       <button id="reset">Show intro again</button>
     </p>
 
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
     <script>
       document.getElementById("reset").addEventListener("click", function() {
         localStorage.clear()

--- a/examples/editor-sdk-menu-position/public/index.html
+++ b/examples/editor-sdk-menu-position/public/index.html
@@ -55,6 +55,6 @@ It can even help when you wanna refine ur slang or formality level. That's espec
       position is set to <code>right</code>.
     </p>
 
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-menu-position/public/menu-position-right.html
+++ b/examples/editor-sdk-menu-position/public/menu-position-right.html
@@ -49,6 +49,6 @@ It can even help when you wanna refine ur slang or formality level. That's espec
       set to <code>left</code>.
     </p>
 
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-quill-imperative/public/index.html
+++ b/examples/editor-sdk-quill-imperative/public/index.html
@@ -72,7 +72,7 @@
     </p>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
 
   <script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
 

--- a/examples/editor-sdk-quill/public/index.html
+++ b/examples/editor-sdk-quill/public/index.html
@@ -75,7 +75,7 @@
     </div>
   </grammarly-editor-plugin>
 
-  <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
 
   <script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
 

--- a/examples/editor-sdk-react-turn-off-ui-elements/package.json
+++ b/examples/editor-sdk-react-turn-off-ui-elements/package.json
@@ -4,7 +4,7 @@
   "description": "Example integration for @grammarly/editor-sdk-react",
   "main": "src/index.js",
   "dependencies": {
-    "@grammarly/editor-sdk-react": "2.3.18",
+    "@grammarly/editor-sdk-react": "2.4.0",
     "react": "17.0.0",
     "react-dom": "17.0.0",
     "react-scripts": "3.4.3"

--- a/examples/editor-sdk-suggestions-config/public/index.html
+++ b/examples/editor-sdk-suggestions-config/public/index.html
@@ -50,6 +50,6 @@
           <li><strong>Informal academic pronouns:</strong> Suggestions for using personal pronouns such as "I" and "you" in academic writing (<code>"informalPronounsAcademic"</code>).</li>
         </ul>
     </p>
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/oxford-comma.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/oxford-comma.html
@@ -36,6 +36,6 @@
       <a href="/index.html">Return to the index.</a>
     </p>
 
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/passive-voice.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/passive-voice.html
@@ -35,6 +35,6 @@
       <a href="/index.html">Return to the index.</a>
     </p>
 
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/stylistic-fragments.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/stylistic-fragments.html
@@ -36,6 +36,6 @@
       <a href="/index.html">Return to the index.</a>
     </p>
 
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-tinymce-imperative/public/index.html
+++ b/examples/editor-sdk-tinymce-imperative/public/index.html
@@ -64,7 +64,7 @@ It can even help when you wanna refine ur slang or formality level. That's espec
     </p>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   <script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/5/tinymce.min.js" referrerpolicy="origin"></script>
 
   <script type="module">

--- a/examples/editor-sdk-tinymce/public/index.html
+++ b/examples/editor-sdk-tinymce/public/index.html
@@ -70,7 +70,7 @@ It can even help when you wanna refine ur slang or formality level. That's espec
     </div>
   </grammarly-editor-plugin>
 
-  <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   <script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/5/tinymce.min.js" referrerpolicy="origin"></script>
 
   <script type="text/javascript">

--- a/examples/editor-sdk-tone/public/index.html
+++ b/examples/editor-sdk-tone/public/index.html
@@ -51,6 +51,6 @@
       </div>
     </grammarly-editor-plugin>
 
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk-turn-off-ui-elements/public/index.html
+++ b/examples/editor-sdk-turn-off-ui-elements/public/index.html
@@ -123,6 +123,6 @@ It can even help when you wanna refine ur slang or formality level. That's espec
       }
     </script>
 
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk/public/index.html
+++ b/examples/editor-sdk/public/index.html
@@ -78,6 +78,6 @@ It can even help when you wanna refine ur slang or formality level. That's espec
       </div>
     </grammarly-editor-plugin>
 
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/editor-sdk/public/tone.html
+++ b/examples/editor-sdk/public/tone.html
@@ -74,6 +74,6 @@ Thank you all for being here today, and welcome to the third annual TRTL confere
         </p>
       </div>
     </grammarly-editor-plugin>
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_9m1fYK3MPQxwKsib5CxtpB"></script>
   </body>
 </html>

--- a/examples/electron/index.html
+++ b/examples/electron/index.html
@@ -78,7 +78,7 @@ It can even help when you wanna refine ur slang or formality level. That's espec
       </div>
     </grammarly-editor-plugin>
 
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18?clientId=client_CAsxR7Djxg9EiT9VCyE3uP"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0?clientId=client_CAsxR7Djxg9EiT9VCyE3uP"></script>
     <script>
       Grammarly.init().then((grammarly) => {
         window.registerGrammarlyAuthCallback(url => {

--- a/examples/trusted-auth/public/index.html
+++ b/examples/trusted-auth/public/index.html
@@ -41,7 +41,7 @@
   <body>
     <h2>Textarea with Trusted Auth</h2>
 
-    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.3.18"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@grammarly/editor-sdk@2.4.0"></script>
 
     <grammarly-editor-plugin client-id="YOUR_CLIENT_ID">
       <textarea rows="10">


### PR DESCRIPTION
The examples have now been updated to version [`2.4.0`](https://developer.grammarly.com/docs/changelog/#_2-4-0-2023-05-17).

Notable updates:
- The autocomplete feature now supports [emoji suggestions](https://developer.grammarly.com/docs/autocomplete#emoji-autocomplete).
  - Whereas the implementation of the [`autocomplete`](https://developer.grammarly.com/docs/api/editor-sdk/editorconfig) property in [EditorConfig](https://developer.grammarly.com/docs/api/editor-sdk/editorconfig#autocomplete) previously generated as `autocomplete?: "on" | "off";`, it now generates as `autocomplete?: string;` with the following values:
    - `"on"`: Plugin offers autocomplete and emoji autocomplete suggestions
    - `"text"`: Plugin offers autocomplete suggestions without emoji autocomplete
    - `"emoji"`: Plugin offers emoji autocomplete suggestions without core autocomplete functionality
    - `"off"`: Plugin does not offer autocomplete or emoji autocomplete suggestions
  - Autocomplete and emoji autocomplete functionality are only available on the Plus plan (the paid plan) of the Text Editor SDK.
- New documentation page for [writing suggestions](https://developer.grammarly.com/docs/writing-suggestions). This page details `Dialect`, `Domain`, and `SuggestionCategories` in more detail, and the page attempts to give more visibility into the logic that is used to surface writing suggestions in the Text Editor Plugin.
  - Dialect and Domain configuration are available on the Free plan, but Suggestion Category configuration is only available on the Plus plan.
- New documentation page for [custom events](https://developer.grammarly.com/docs/events). This page details events that can be listened for and handled for free against events that can be listened for and handled (only emitted) on the Plus plan. 
  - In case you missed it, as of [`2.3.14`](https://developer.grammarly.com/docs/changelog/#_2-3-14-2023-03-28), the plugin supports a new free event: `suggestion-card-action`. The event returns a JSON object of this format: `{ action: "accept" | "dismiss" | "close"; }` that lets you know whether a suggestion has been accepted, dismissed, or closed (the `x` button) after a suggestion card has been opened.