### PR TITLE
Update Editor.js SDK example to sync with Editor.js popover functionality

### DIFF
--- a/examples/editor-sdk-editorjs/public/index.html
+++ b/examples/editor-sdk-editorjs/public/index.html
@@ -52,11 +52,11 @@
     <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest"></script>
 
     <script>
-      window.addEventListener("DOMContentLoaded", async () => {
+      (async () => {
         const grammarly = await Grammarly.init("client_9m1fYK3MPQxwKsib5CxtpB");
 
         const config = {
-          activation: "immediate",
+          activation: "immediate"
         };
 
         // Initialize an empty EditorJS editor
@@ -67,55 +67,32 @@
               {
                 type: "paragraph",
                 data: {
-                  text: "Mispellings and grammatical errors can effect your credibility. The same goes for misused commas, and other types of punctuation . Not only will Grammarly underline these issues in red, it will also showed you how to correctly write the sentence.",
-                },
+                  text:
+                    "Mispellings and grammatical errors can effect your credibility. The same goes for misused commas, and other types of punctuation . Not only will Grammarly underline these issues in red, it will also showed you how to correctly write the sentence."
+                }
               },
               {
                 type: "paragraph",
                 data: {
-                  text: "Underlines that are blue indicate that Grammarly has spotted a sentence that is unnecessarily wordy. You'll find suggestions that can possibly help you revise a wordy sentence in an effortless manner.",
-                },
+                  text:
+                    "Underlines that are blue indicate that Grammarly has spotted a sentence that is unnecessarily wordy. You'll find suggestions that can possibly help you revise a wordy sentence in an effortless manner."
+                }
               },
               {
                 type: "paragraph",
                 data: {
-                  text: "But wait...there's more? Grammarly can give you very helpful feedback on your writing. Passive voice can be fixed by Grammarly, and it can handle classical word-choice mistakes. It can even help when you wanna refine ur slang or formality level. That's especially useful when writing for a broad audience ranging from businessmen to friends and family, don't you think? It'll inspect your vocabulary carefully and suggest the best word to make sure you don't have to analyze your writing too much.",
-                },
-              },
-            ],
+                  text:
+                    "But wait...there's more? Grammarly can give you very helpful feedback on your writing. Passive voice can be fixed by Grammarly, and it can handle classical word-choice mistakes. It can even help when you wanna refine ur slang or formality level. That's especially useful when writing for a broad audience ranging from businessmen to friends and family, don't you think? It'll inspect your vocabulary carefully and suggest the best word to make sure you don't have to analyze your writing too much."
+                }
+              }
+            ]
           },
           onReady: () => {
             const initialEditor = document.querySelector("#editorjs");
-            editableDivs = initialEditor.querySelectorAll("[contenteditable]");
-            editableDivs.forEach((editable) => {
-              grammarly.addPlugin(editable, config);
-            });
-          },
-          onChange: (api, events) => {
-            const blockEvents = Array.isArray(events) ? events : [events];
-            blockEvents.forEach((event) => {
-              const type = event.type;
-
-              // Add the Grammarly plugin to new blocks
-              if (type === "block-added") {
-                const block = event.detail.target.holder;
-                const editableDiv = block.querySelector("[contenteditable]");
-                grammarly.addPlugin(editableDiv);
-              }
-
-              // Reconnect the Grammarly plugin if the block moves
-              if (type === "block-moved") {
-                const block = event.detail.target.holder;
-                const editableDiv = block.querySelector("[contenteditable]");
-                const grammarlyPlugin = block.querySelector(
-                  "grammarly-editor-plugin"
-                );
-                grammarlyPlugin.connect(editableDiv);
-              }
-            });
-          },
+            grammarly.addPlugin(initialEditor, config);
+          }
         });
-      });
+      })();
     </script>
   </body>
 </html>

--- a/examples/editor-sdk-editorjs/public/index.html
+++ b/examples/editor-sdk-editorjs/public/index.html
@@ -64,14 +64,14 @@
                 type: "paragraph",
                 data: {
                   text:
-                    "Mispellings and grammatical errors can effect your credibility. The same goes for misused commas, and other types of punctuation . Not only will Grammarly underline these issues in red, it will also showed you how to correctly write the sentence."
+                    "Did you know that mispellings and grammatical errors can effect your credibility? The same goes for misused commas, and other types of punctuation . Not only will Grammarly underline these issues in red, it will also showed you how to correctly write the sentence."
                 }
               },
               {
                 type: "paragraph",
                 data: {
                   text:
-                    "Underlines that are blue indicate that Grammarly has spotted a sentence that is unnecessarily wordy. You'll find suggestions that can possibly help you revise a wordy sentence in an effortless manner."
+                    "On the topic of rewriting setences, underlines that are blue indicate that Grammarly has spotted a sentence that is unnecessarily wordy. You'll find suggestions that can possibly help you revise a wordy sentence in an effortless manner."
                 }
               },
               {

--- a/examples/editor-sdk-editorjs/public/index.html
+++ b/examples/editor-sdk-editorjs/public/index.html
@@ -52,11 +52,11 @@
     <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest"></script>
 
     <script>
-      (async () => {
+      window.addEventListener("DOMContentLoaded", async () => {
         const grammarly = await Grammarly.init("client_9m1fYK3MPQxwKsib5CxtpB");
 
         const config = {
-          activation: "immediate"
+          activation: "immediate",
         };
 
         // Initialize an empty EditorJS editor
@@ -67,25 +67,22 @@
               {
                 type: "paragraph",
                 data: {
-                  text:
-                    "Mispellings and grammatical errors can effect your credibility. The same goes for misused commas, and other types of punctuation . Not only will Grammarly underline these issues in red, it will also showed you how to correctly write the sentence."
-                }
+                  text: "Mispellings and grammatical errors can effect your credibility. The same goes for misused commas, and other types of punctuation . Not only will Grammarly underline these issues in red, it will also showed you how to correctly write the sentence.",
+                },
               },
               {
                 type: "paragraph",
                 data: {
-                  text:
-                    "Underlines that are blue indicate that Grammarly has spotted a sentence that is unnecessarily wordy. You'll find suggestions that can possibly help you revise a wordy sentence in an effortless manner."
-                }
+                  text: "Underlines that are blue indicate that Grammarly has spotted a sentence that is unnecessarily wordy. You'll find suggestions that can possibly help you revise a wordy sentence in an effortless manner.",
+                },
               },
               {
                 type: "paragraph",
                 data: {
-                  text:
-                    "But wait...there's more? Grammarly can give you very helpful feedback on your writing. Passive voice can be fixed by Grammarly, and it can handle classical word-choice mistakes. It can even help when you wanna refine ur slang or formality level. That's especially useful when writing for a broad audience ranging from businessmen to friends and family, don't you think? It'll inspect your vocabulary carefully and suggest the best word to make sure you don't have to analyze your writing too much."
-                }
-              }
-            ]
+                  text: "But wait...there's more? Grammarly can give you very helpful feedback on your writing. Passive voice can be fixed by Grammarly, and it can handle classical word-choice mistakes. It can even help when you wanna refine ur slang or formality level. That's especially useful when writing for a broad audience ranging from businessmen to friends and family, don't you think? It'll inspect your vocabulary carefully and suggest the best word to make sure you don't have to analyze your writing too much.",
+                },
+              },
+            ],
           },
           onReady: () => {
             const initialEditor = document.querySelector("#editorjs");
@@ -94,16 +91,31 @@
               grammarly.addPlugin(editable, config);
             });
           },
-          onChange: (api, event) => {
-            const type = event.type;
-            if (type === "block-added") {
-              const detail = event.detail.target.holder;
-              editableDiv = detail.querySelector("[contenteditable]");
-              grammarly.addPlugin(editableDiv, config);
-            }
-          }
+          onChange: (api, events) => {
+            const blockEvents = Array.isArray(events) ? events : [events];
+            blockEvents.forEach((event) => {
+              const type = event.type;
+
+              // Add the Grammarly plugin to new blocks
+              if (type === "block-added") {
+                const block = event.detail.target.holder;
+                const editableDiv = block.querySelector("[contenteditable]");
+                grammarly.addPlugin(editableDiv);
+              }
+
+              // Reconnect the Grammarly plugin if the block moves
+              if (type === "block-moved") {
+                const block = event.detail.target.holder;
+                const editableDiv = block.querySelector("[contenteditable]");
+                const grammarlyPlugin = block.querySelector(
+                  "grammarly-editor-plugin"
+                );
+                grammarlyPlugin.connect(editableDiv);
+              }
+            });
+          },
         });
-      })();
+      });
     </script>
   </body>
 </html>

--- a/examples/editor-sdk-editorjs/public/index.html
+++ b/examples/editor-sdk-editorjs/public/index.html
@@ -52,12 +52,8 @@
     <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest"></script>
 
     <script>
-      (async () => {
+      window.addEventListener("DOMContentLoaded", async () => {
         const grammarly = await Grammarly.init("client_9m1fYK3MPQxwKsib5CxtpB");
-
-        const config = {
-          activation: "immediate"
-        };
 
         // Initialize an empty EditorJS editor
         const editor = new EditorJS({
@@ -89,10 +85,10 @@
           },
           onReady: () => {
             const initialEditor = document.querySelector("#editorjs");
-            grammarly.addPlugin(initialEditor, config);
+            grammarly.addPlugin(initialEditor);
           }
         });
-      })();
+      })
     </script>
   </body>
 </html>


### PR DESCRIPTION
Simplifies the existing demo and fixes an issue where the plugin doesn't work for any block that has been moved. See working demo here: https://codesandbox.io/s/github/cwatkins/grammarly-for-developers/tree/update-editor-js-example/examples/editor-sdk-editorjs?file=/public/index.html