### PR TITLE
Fix CodeSandbox examples

### DIFF
--- a/examples/editor-sdk-activation/sandbox.config.json
+++ b/examples/editor-sdk-activation/sandbox.config.json
@@ -1,0 +1,6 @@
+{
+    "infiniteLoopProtection": true,
+    "hardReloadOnChange": true,
+    "view": "browser",
+    "template": "create-react-app"
+}

--- a/examples/editor-sdk-autocomplete/sandbox.config.json
+++ b/examples/editor-sdk-autocomplete/sandbox.config.json
@@ -1,0 +1,6 @@
+{
+    "infiniteLoopProtection": true,
+    "hardReloadOnChange": true,
+    "view": "browser",
+    "template": "create-react-app"
+}

--- a/examples/editor-sdk-ckeditor-imperative/package.json
+++ b/examples/editor-sdk-ckeditor-imperative/package.json
@@ -2,6 +2,7 @@
   "name": "grammarly-example-editor-sdk-ckeditor-imperative",
   "version": "1.0.2",
   "description": "Example that uses @grammarly/editor-sdk in an imperative way with CKEditor",
+  "main": "public/index.html",
   "dependencies": {},
   "devDependencies": {
     "typescript": "3.8.3"

--- a/examples/editor-sdk-ckeditor-imperative/sandbox.config.json
+++ b/examples/editor-sdk-ckeditor-imperative/sandbox.config.json
@@ -1,0 +1,6 @@
+{
+    "infiniteLoopProtection": true,
+    "hardReloadOnChange": true,
+    "view": "browser",
+    "template": "create-react-app"
+}

--- a/examples/editor-sdk-ckeditor/package.json
+++ b/examples/editor-sdk-ckeditor/package.json
@@ -2,6 +2,7 @@
   "name": "grammarly-example-editor-sdk-ckeditor",
   "version": "1.0.2",
   "description": "Example that uses @grammarly/editor-sdk with CKEditor",
+  "main": "public/index.html",
   "dependencies": {},
   "devDependencies": {
     "typescript": "3.8.3"

--- a/examples/editor-sdk-ckeditor/sandbox.config.json
+++ b/examples/editor-sdk-ckeditor/sandbox.config.json
@@ -1,0 +1,6 @@
+{
+    "infiniteLoopProtection": true,
+    "hardReloadOnChange": true,
+    "view": "browser",
+    "template": "create-react-app"
+}

--- a/examples/editor-sdk-document-dialect/public/dialects/american-english.html
+++ b/examples/editor-sdk-document-dialect/public/dialects/american-english.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <link rel="stylesheet" href="/style.css" />
+    <link rel="stylesheet" href="./style.css" />
     <title>Demo App</title>
   </head>
   <body>

--- a/examples/editor-sdk-document-dialect/public/dialects/american-english.html
+++ b/examples/editor-sdk-document-dialect/public/dialects/american-english.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <link rel="stylesheet" href="./style.css" />
+    <link rel="stylesheet" href="../style.css" />
     <title>Demo App</title>
   </head>
   <body>

--- a/examples/editor-sdk-document-dialect/public/dialects/australian-english.html
+++ b/examples/editor-sdk-document-dialect/public/dialects/australian-english.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <link rel="stylesheet" href="/style.css" />
+    <link rel="stylesheet" href="./style.css" />
     <title>Demo App</title>
   </head>
   <body>

--- a/examples/editor-sdk-document-dialect/public/dialects/australian-english.html
+++ b/examples/editor-sdk-document-dialect/public/dialects/australian-english.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <link rel="stylesheet" href="./style.css" />
+    <link rel="stylesheet" href="../style.css" />
     <title>Demo App</title>
   </head>
   <body>

--- a/examples/editor-sdk-document-dialect/public/dialects/british-english.html
+++ b/examples/editor-sdk-document-dialect/public/dialects/british-english.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <link rel="stylesheet" href="/style.css" />
+    <link rel="stylesheet" href="./style.css" />
     <title>Demo App</title>
   </head>
   <body>

--- a/examples/editor-sdk-document-dialect/public/dialects/british-english.html
+++ b/examples/editor-sdk-document-dialect/public/dialects/british-english.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <link rel="stylesheet" href="./style.css" />
+    <link rel="stylesheet" href="../style.css" />
     <title>Demo App</title>
   </head>
   <body>

--- a/examples/editor-sdk-document-dialect/public/dialects/canadian-english.html
+++ b/examples/editor-sdk-document-dialect/public/dialects/canadian-english.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <link rel="stylesheet" href="/style.css" />
+    <link rel="stylesheet" href="./style.css" />
     <title>Demo App</title>
   </head>
   <body>

--- a/examples/editor-sdk-document-dialect/public/dialects/canadian-english.html
+++ b/examples/editor-sdk-document-dialect/public/dialects/canadian-english.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <link rel="stylesheet" href="./style.css" />
+    <link rel="stylesheet" href="../style.css" />
     <title>Demo App</title>
   </head>
   <body>

--- a/examples/editor-sdk-document-dialect/public/dialects/indian-english.html
+++ b/examples/editor-sdk-document-dialect/public/dialects/indian-english.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <link rel="stylesheet" href="/style.css" />
+    <link rel="stylesheet" href="./style.css" />
     <title>Demo App</title>
   </head>
   <body>

--- a/examples/editor-sdk-document-dialect/public/dialects/indian-english.html
+++ b/examples/editor-sdk-document-dialect/public/dialects/indian-english.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <link rel="stylesheet" href="./style.css" />
+    <link rel="stylesheet" href="../style.css" />
     <title>Demo App</title>
   </head>
   <body>

--- a/examples/editor-sdk-document-dialect/public/index.html
+++ b/examples/editor-sdk-document-dialect/public/index.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="style.css">
     <title>Demo App</title>
   </head>
   <body>

--- a/examples/editor-sdk-document-dialect/sandbox.config.json
+++ b/examples/editor-sdk-document-dialect/sandbox.config.json
@@ -1,0 +1,6 @@
+{
+    "infiniteLoopProtection": true,
+    "hardReloadOnChange": true,
+    "view": "browser",
+    "template": "create-react-app"
+}

--- a/examples/editor-sdk-document-domain/public/domains/academic-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/academic-domain.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Document Domain demo</title>
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="./style.css">
   </head>
   <body>
     <h2>Document Domain (Academic)</h2>

--- a/examples/editor-sdk-document-domain/public/domains/academic-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/academic-domain.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Document Domain demo</title>
-    <link rel="stylesheet" href="./style.css">
+    <link rel="stylesheet" href="../style.css">
   </head>
   <body>
     <h2>Document Domain (Academic)</h2>

--- a/examples/editor-sdk-document-domain/public/domains/business-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/business-domain.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Document Domain demo</title>
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="./style.css">
   </head>
   <body>
     <h2>Document Domain (Business)</h2>

--- a/examples/editor-sdk-document-domain/public/domains/business-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/business-domain.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Document Domain demo</title>
-    <link rel="stylesheet" href="./style.css">
+    <link rel="stylesheet" href="../style.css">
   </head>
   <body>
     <h2>Document Domain (Business)</h2>

--- a/examples/editor-sdk-document-domain/public/domains/casual-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/casual-domain.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Document Domain demo</title>
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="./style.css">
   </head>
   <body>
     <h2>Document Domain (Casual)</h2>

--- a/examples/editor-sdk-document-domain/public/domains/casual-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/casual-domain.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Document Domain demo</title>
-    <link rel="stylesheet" href="./style.css">
+    <link rel="stylesheet" href="../style.css">
   </head>
   <body>
     <h2>Document Domain (Casual)</h2>

--- a/examples/editor-sdk-document-domain/public/domains/creative-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/creative-domain.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Document Domain demo</title>
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="./style.css">
   </head>
   <body>
     <h2>Document Domain (Creative)</h2>

--- a/examples/editor-sdk-document-domain/public/domains/creative-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/creative-domain.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Document Domain demo</title>
-    <link rel="stylesheet" href="./style.css">
+    <link rel="stylesheet" href="../style.css">
   </head>
   <body>
     <h2>Document Domain (Creative)</h2>

--- a/examples/editor-sdk-document-domain/public/domains/mail-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/mail-domain.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Document Domain demo</title>
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="./style.css">
   </head>
   <body>
     <h2>Document Domain (Mail)</h2>

--- a/examples/editor-sdk-document-domain/public/domains/mail-domain.html
+++ b/examples/editor-sdk-document-domain/public/domains/mail-domain.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Document Domain demo</title>
-    <link rel="stylesheet" href="./style.css">
+    <link rel="stylesheet" href="../style.css">
   </head>
   <body>
     <h2>Document Domain (Mail)</h2>

--- a/examples/editor-sdk-document-domain/public/index.html
+++ b/examples/editor-sdk-document-domain/public/index.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Document Domain demo</title>
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="style.css">
   </head>
   <body>
     <h2>Document Domain (General)</h2>

--- a/examples/editor-sdk-document-domain/sandbox.config.json
+++ b/examples/editor-sdk-document-domain/sandbox.config.json
@@ -1,0 +1,6 @@
+{
+    "infiniteLoopProtection": true,
+    "hardReloadOnChange": true,
+    "view": "browser",
+    "template": "create-react-app"
+}

--- a/examples/editor-sdk-events/sandbox.config.json
+++ b/examples/editor-sdk-events/sandbox.config.json
@@ -1,0 +1,6 @@
+{
+    "infiniteLoopProtection": true,
+    "hardReloadOnChange": true,
+    "view": "browser",
+    "template": "create-react-app"
+}

--- a/examples/editor-sdk-intro-text/sandbox.config.json
+++ b/examples/editor-sdk-intro-text/sandbox.config.json
@@ -1,0 +1,6 @@
+{
+    "infiniteLoopProtection": true,
+    "hardReloadOnChange": true,
+    "view": "browser",
+    "template": "create-react-app"
+}

--- a/examples/editor-sdk-menu-position/public/index.html
+++ b/examples/editor-sdk-menu-position/public/index.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <link rel="stylesheet" href="/style.css" />
+    <link rel="stylesheet" href="style.css" />
     <title>Grammarly Button Menu Position</title>
   </head>
   <body>

--- a/examples/editor-sdk-menu-position/sandbox.config.json
+++ b/examples/editor-sdk-menu-position/sandbox.config.json
@@ -1,0 +1,6 @@
+{
+    "infiniteLoopProtection": true,
+    "hardReloadOnChange": true,
+    "view": "browser",
+    "template": "create-react-app"
+}

--- a/examples/editor-sdk-quill-imperative/package.json
+++ b/examples/editor-sdk-quill-imperative/package.json
@@ -2,6 +2,7 @@
   "name": "grammarly-example-editor-sdk-quill-imperative",
   "version": "1.0.2",
   "description": "Example that uses @grammarly/editor-sdk in an imperative way with Quill",
+  "main": "public/index.html",
   "dependencies": {},
   "devDependencies": {
     "typescript": "3.8.3"

--- a/examples/editor-sdk-quill-imperative/sandbox.config.json
+++ b/examples/editor-sdk-quill-imperative/sandbox.config.json
@@ -1,0 +1,6 @@
+{
+    "infiniteLoopProtection": true,
+    "hardReloadOnChange": true,
+    "view": "browser",
+    "template": "create-react-app"
+}

--- a/examples/editor-sdk-quill/package.json
+++ b/examples/editor-sdk-quill/package.json
@@ -2,6 +2,7 @@
   "name": "grammarly-example-editor-sdk-quill",
   "version": "1.0.2",
   "description": "Example that uses @grammarly/editor-sdk with Quill",
+  "main": "public/index.html",
   "dependencies": {},
   "devDependencies": {
     "typescript": "3.8.3"

--- a/examples/editor-sdk-quill/sandbox.config.json
+++ b/examples/editor-sdk-quill/sandbox.config.json
@@ -1,0 +1,6 @@
+{
+    "infiniteLoopProtection": true,
+    "hardReloadOnChange": true,
+    "view": "browser",
+    "template": "create-react-app"
+}

--- a/examples/editor-sdk-react/readme.md
+++ b/examples/editor-sdk-react/readme.md
@@ -4,7 +4,7 @@ This demo shows how to add the [Grammarly Text Editor SDK](https://developer.gra
 
 ## Try the demo
 
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/javascript-plugin/tree/main/examples/editor-sdk-react).
+You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-react).
 
 ## How it works
 

--- a/examples/editor-sdk-suggestions-config/public/index.html
+++ b/examples/editor-sdk-suggestions-config/public/index.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Suggestion Categories demo</title>
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="style.css">
   </head>
   <body>
     <h2>Suggestion Categories (Default)</h2>

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/oxford-comma.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/oxford-comma.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Suggestion Categories demo</title>
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="./style.css">
   </head>
   <body>
     <h2>Suggestion categories (Oxford comma turned "on")</h2>

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/oxford-comma.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/oxford-comma.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Suggestion Categories demo</title>
-    <link rel="stylesheet" href="./style.css">
+    <link rel="stylesheet" href="../style.css">
   </head>
   <body>
     <h2>Suggestion categories (Oxford comma turned "on")</h2>

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/passive-voice.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/passive-voice.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Suggestion Categories demo</title>
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="./style.css">
   </head>
   <body>
     <h2>Suggestion categories (Passive voice suggestions turned "on")</h2>

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/passive-voice.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/passive-voice.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Suggestion Categories demo</title>
-    <link rel="stylesheet" href="./style.css">
+    <link rel="stylesheet" href="../style.css">
   </head>
   <body>
     <h2>Suggestion categories (Passive voice suggestions turned "on")</h2>

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/stylistic-fragments.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/stylistic-fragments.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Suggestion Categories demo</title>
-    <link rel="stylesheet" href="./style.css">
+    <link rel="stylesheet" href="../style.css">
   </head>
   <body>
     <h2>Suggestion Categories (Completing stylistic fragments turned "on")</h2>

--- a/examples/editor-sdk-suggestions-config/public/suggestion-categories/stylistic-fragments.html
+++ b/examples/editor-sdk-suggestions-config/public/suggestion-categories/stylistic-fragments.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Suggestion Categories demo</title>
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="./style.css">
   </head>
   <body>
     <h2>Suggestion Categories (Completing stylistic fragments turned "on")</h2>

--- a/examples/editor-sdk-suggestions-config/sandbox.config.json
+++ b/examples/editor-sdk-suggestions-config/sandbox.config.json
@@ -1,0 +1,6 @@
+{
+    "infiniteLoopProtection": true,
+    "hardReloadOnChange": true,
+    "view": "browser",
+    "template": "create-react-app"
+}

--- a/examples/editor-sdk-tinymce-imperative/package.json
+++ b/examples/editor-sdk-tinymce-imperative/package.json
@@ -2,6 +2,7 @@
   "name": "grammarly-example-editor-sdk-tinymce-imperative",
   "version": "1.0.2",
   "description": "Example that uses @grammarly/editor-sdk in an imperative way with TinyMCE",
+  "main": "public/index.html",
   "dependencies": {},
   "devDependencies": {
     "typescript": "3.8.3"

--- a/examples/editor-sdk-tinymce-imperative/sandbox.config.json
+++ b/examples/editor-sdk-tinymce-imperative/sandbox.config.json
@@ -1,0 +1,6 @@
+{
+    "infiniteLoopProtection": true,
+    "hardReloadOnChange": true,
+    "view": "browser",
+    "template": "create-react-app"
+}

--- a/examples/editor-sdk-tinymce/package.json
+++ b/examples/editor-sdk-tinymce/package.json
@@ -2,6 +2,7 @@
   "name": "grammarly-example-editor-sdk-tinymce",
   "version": "1.0.2",
   "description": "Example that uses @grammarly/editor-sdk with TinyMCE",
+  "main": "public/index.html",
   "dependencies": {},
   "devDependencies": {
     "typescript": "3.8.3"

--- a/examples/editor-sdk-tinymce/sandbox.config.json
+++ b/examples/editor-sdk-tinymce/sandbox.config.json
@@ -1,0 +1,6 @@
+{
+    "infiniteLoopProtection": true,
+    "hardReloadOnChange": true,
+    "view": "browser",
+    "template": "create-react-app"
+}

--- a/examples/editor-sdk-tone/package.json
+++ b/examples/editor-sdk-tone/package.json
@@ -2,5 +2,5 @@
   "name": "grammarly-example-editor-sdk-tone",
   "version": "1.0.2",
   "main": "public/index.html",
-  "description": "Example integration for @grammarly/editor-sdk with Tone Detector"
+  "description": "Example integration for @grammarly/editor-sdk with Tone Detector" 
 }

--- a/examples/editor-sdk-tone/sandbox.config.json
+++ b/examples/editor-sdk-tone/sandbox.config.json
@@ -1,0 +1,6 @@
+{
+    "infiniteLoopProtection": true,
+    "hardReloadOnChange": true,
+    "view": "browser",
+    "template": "create-react-app"
+}

--- a/examples/editor-sdk-turn-off-ui-elements/sandbox.config.json
+++ b/examples/editor-sdk-turn-off-ui-elements/sandbox.config.json
@@ -1,0 +1,6 @@
+{
+    "infiniteLoopProtection": true,
+    "hardReloadOnChange": true,
+    "view": "browser",
+    "template": "create-react-app"
+}

--- a/examples/editor-sdk-vue/readme.md
+++ b/examples/editor-sdk-vue/readme.md
@@ -4,7 +4,7 @@ This demo shows how to add the [Grammarly Text Editor SDK](https://developer.gra
 
 ## Try the demo
 
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/javascript-plugin/tree/main/examples/editor-sdk-vue).
+You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-vue).
 
 ## How it works
 

--- a/examples/editor-sdk/package.json
+++ b/examples/editor-sdk/package.json
@@ -2,6 +2,7 @@
   "name": "grammarly-example-editor-sdk",
   "version": "1.0.2",
   "description": "Example integration for @grammarly/editor-sdk",
+  "main": "public/index.html",
   "dependencies": {},
   "devDependencies": {
     "typescript": "3.8.3"

--- a/examples/editor-sdk/sandbox.config.json
+++ b/examples/editor-sdk/sandbox.config.json
@@ -1,0 +1,6 @@
+{
+    "infiniteLoopProtection": true,
+    "hardReloadOnChange": true,
+    "view": "browser",
+    "template": "create-react-app"
+}

--- a/examples/trusted-auth/package.json
+++ b/examples/trusted-auth/package.json
@@ -2,6 +2,7 @@
   "name": "trusted-auth",
   "version": "1.0.0",
   "description": "Trusted Authentication code examples",
+  "main": "public/index.html",
   "scripts": {},
   "author": ""
 }

--- a/examples/trusted-auth/sandbox.config.json
+++ b/examples/trusted-auth/sandbox.config.json
@@ -1,0 +1,6 @@
+{
+    "infiniteLoopProtection": true,
+    "hardReloadOnChange": true,
+    "view": "browser",
+    "template": "create-react-app"
+}


### PR DESCRIPTION
* Add configurations to specify `main` path.
* Fix path issues with many `style.css` imports.
* Add `sandbox.config.json` files to broken examples.
* Update older CodeSandbox references in READMEs to current `grammarly-for-developers` repository.

**Important:** When testing, there are known issues with Chrome / Incognito mode. Please use another browser (e.g. FireFox).