### PR TITLE
Use Vite for Editor-JS

### DIFF
--- a/examples/editor-sdk-editorjs/package.json
+++ b/examples/editor-sdk-editorjs/package.json
@@ -1,16 +1,14 @@
 {
   "name": "grammarly-example-editor-sdk-editorjs",
   "version": "1.0.2",
-  "main": "public/index.html",
   "description": "Example that uses @grammarly/editor-sdk with Editor.js",
+    "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
   "dependencies": {},
   "devDependencies": {
-    "typescript": "3.8.3"
-  },
-  "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
+    "vite": "^4.3.9"
   }
 }

--- a/examples/editor-sdk-editorjs/readme.md
+++ b/examples/editor-sdk-editorjs/readme.md
@@ -2,9 +2,38 @@
 
 This demo shows how to add the [Grammarly Text Editor SDK](https://developer.grammarly.com/) to a [Editor.js](https://editorjs.io/) rich text editor. The example uses [addPlugin()](https://developer.grammarly.com/docs/api/editor-sdk/editorsdk#addplugin) to add Grammarly suggestions in an imperative way.
 
-## Try the demo
+## Try the demo online
 
 You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-editorjs?file=/public/index.html).
+
+## Try the demo locally
+You can try the demo locally using Vite. Navigate to the `editor-sdk-editorjs` directory and follow the steps below.
+
+### 1. Install the project's dependencies.
+
+With npm:\
+`npm install`
+
+With pnpm:\
+`pnpm install`
+
+With yarn:\
+`yarn install` 
+
+### 2. Run the project.
+
+With npm:\
+`npm run vite`
+
+With pnpm:\
+`pnpm vite`
+
+With yarn:\
+`yarn vite`
+
+### 3. Navigate the project.
+
+Once the project is running, you will see a message from Vite indicating where the project is running. By default, the project runs on localhost:5173. 
 
 ## How it works
 

--- a/examples/editor-sdk-editorjs/sandbox.config.json
+++ b/examples/editor-sdk-editorjs/sandbox.config.json
@@ -1,6 +1,0 @@
-{
-  "infiniteLoopProtection": true,
-  "hardReloadOnChange": true,
-  "view": "browser",
-  "template": "create-react-app"
-}

--- a/examples/editor-sdk-editorjs/vite.config.js
+++ b/examples/editor-sdk-editorjs/vite.config.js
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  root: "./public",
+})


### PR DESCRIPTION
Updates the Editor JS example to use Vite, allow it to run locally and on CodeSandboxes Cloud Sandbox.  See the live example here:  https://codesandbox.io/s/github/cwatkins/grammarly-for-developers/tree/editor-js-use-vite/examples/editor-sdk-editorjs?file=/public/index.html