### PR TITLE
Remove CodeSandbox links

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ You can find Grammarly for Developers on social media. Be sure to follow us on y
 The [Grammarly for Developers blog](https://www.grammarly.com/blog/developer/) is your go-to source for our latest announcements, updates, tutorials, stories, articles, and more. Read the latest posts below!
 
 <!-- BLOG-POST-LIST:START -->
+- [How We Optimize Performance for the Grammarly Text Editor SDK](https://www.grammarly.com/blog/developer/how-we-optimize-performance/)
 - [The Syntax: What’s New in Grammarly for Developers &lpar;June 2023&rpar;](https://www.grammarly.com/blog/developer/syntax-whats-new-june-2023/)
 - [10 Best Practices for Writing Documentation &lpar;For Those Who Would Rather Do Anything Else&rpar;](https://www.grammarly.com/blog/developer/10-best-practices-writing-documentation/)
 - [How to Add Writing Assistance to Any JavaScript App in Minutes](https://www.grammarly.com/blog/developer/writing-assistance-javascript-app/)
 - [The Syntax: What’s New in Grammarly for Developers &lpar;February 2023&rpar;](https://www.grammarly.com/blog/developer/syntax-whats-new-february-2023/)
-- [5 Strategies for Using Writing to Level Up Your Technical Career](https://www.grammarly.com/blog/developer/5-strategies-using-writing-level-up-technical-career/)
 <!-- BLOG-POST-LIST:END -->
 
 ## Other resources 📖

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The [Grammarly for Developers blog](https://www.grammarly.com/blog/developer/) i
 - [The Syntax: What’s New in Grammarly for Developers &lpar;June 2023&rpar;](https://www.grammarly.com/blog/developer/syntax-whats-new-june-2023/)
 - [10 Best Practices for Writing Documentation &lpar;For Those Who Would Rather Do Anything Else&rpar;](https://www.grammarly.com/blog/developer/10-best-practices-writing-documentation/)
 - [How to Add Writing Assistance to Any JavaScript App in Minutes](https://www.grammarly.com/blog/developer/writing-assistance-javascript-app/)
-- [The Syntax: What’s New in Grammarly for Developers &lpar;February 2023&rpar;](https://www.grammarly.com/blog/developer/syntax-whats-new-february-2023/)
+- [3 Ways to Avoid Being a Jerk When You Write](https://www.grammarly.com/blog/developer/3-ways-to-avoid-being-a-jerk-when-you-write/)
 <!-- BLOG-POST-LIST:END -->
 
 ## Other resources 📖

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The [Grammarly for Developers blog](https://www.grammarly.com/blog/developer/) i
 - [The Syntax: What’s New in Grammarly for Developers &lpar;June 2023&rpar;](https://www.grammarly.com/blog/developer/syntax-whats-new-june-2023/)
 - [10 Best Practices for Writing Documentation &lpar;For Those Who Would Rather Do Anything Else&rpar;](https://www.grammarly.com/blog/developer/10-best-practices-writing-documentation/)
 - [How to Add Writing Assistance to Any JavaScript App in Minutes](https://www.grammarly.com/blog/developer/writing-assistance-javascript-app/)
-- [3 Ways to Avoid Being a Jerk When You Write](https://www.grammarly.com/blog/developer/3-ways-to-avoid-being-a-jerk-when-you-write/)
+- [The Syntax: What’s New in Grammarly for Developers &lpar;February 2023&rpar;](https://www.grammarly.com/blog/developer/syntax-whats-new-february-2023/)
 <!-- BLOG-POST-LIST:END -->
 
 ## Other resources 📖

--- a/examples/demo-angular/readme.md
+++ b/examples/demo-angular/readme.md
@@ -2,12 +2,6 @@
 
 This demo Angular app displays a `<textarea>` with sample text in it. You can use this app while exploring how to use the [Grammarly Text Editor SDK](https://developer.grammarly.com/).
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/demo-angular/).
-
-Note that this demo does _not_ contain the code for using the SDK, so Grammarly suggestions will not appear in the app automatically.
-
 ## How it works
 
 The app contains a `<textarea>`. You can add Grammarly suggestions to the `<textarea>` by creating a [new Grammarly for Developers app](https://developer.grammarly.com/apps) and then following the Quick Start instructions for a JavaScript app.

--- a/examples/demo-html/readme.md
+++ b/examples/demo-html/readme.md
@@ -2,12 +2,6 @@
 
 This demo HTML app contains a `<textarea>`, `<input>`, and `<div>`. You can use this app while exploring how to use the [Grammarly Text Editor SDK](https://developer.grammarly.com/).
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/demo-html?file=/public/index.html).
-
-Note that this demo does _not_ contain the code for using the SDK, so Grammarly suggestions will not appear in the app automatically.
-
 ## How it works
 
 The app contains three text editors. You can add Grammarly suggestions to the text editors by creating a [new Grammarly for Developers app](https://developer.grammarly.com/apps) and then following the Quick Start instructions for an HTML app.

--- a/examples/demo-javascript/readme.md
+++ b/examples/demo-javascript/readme.md
@@ -2,12 +2,6 @@
 
 This demo JavaScript app displays a `<textarea>` with sample text in it. You can use this app while exploring how to use the [Grammarly Text Editor SDK](https://developer.grammarly.com/).
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/demo-javascript?file=/public/index.html).
-
-Note that this demo does _not_ contain the code for using the SDK, so Grammarly suggestions will not appear in the app automatically.
-
 ## How it works
 
 The app contains a `<textarea>`. You can add Grammarly suggestions to the `<textarea>` by creating a [new Grammarly for Developers app](https://developer.grammarly.com/apps) and then following the Quick Start instructions for a JavaScript app.

--- a/examples/demo-react/readme.md
+++ b/examples/demo-react/readme.md
@@ -2,12 +2,6 @@
 
 This demo React app displays a `<textarea>` with sample text in it. You can use this app while exploring how to use the [Grammarly Text Editor SDK](https://developer.grammarly.com/).
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/demo-react?file=/src/Editors.js).
-
-Note that this demo does _not_ contain the code for using the SDK, so Grammarly suggestions will not appear in the app automatically.
-
 ## How it works
 
 The app contains a `<textarea>`. You can add Grammarly suggestions to the `<textarea>` by creating a [new Grammarly for Developers app](https://developer.grammarly.com/apps) and then following the Quick Start instructions for a React app.

--- a/examples/demo-vue/readme.md
+++ b/examples/demo-vue/readme.md
@@ -2,12 +2,6 @@
 
 This demo Vue app displays a `<textarea>` with sample text in it. You can use this app while exploring how to use the [Grammarly Text Editor SDK](https://developer.grammarly.com/).
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/demo-vue?file=/src/components/Editors.vue).
-
-Note that this demo does _not_ contain the code for using the SDK, so Grammarly suggestions will not appear in the app automatically.
-
 ## How it works
 
 The app contains a `<textarea>`. You can add Grammarly suggestions to the `<textarea>` by creating a [new Grammarly for Developers app](https://developer.grammarly.com/apps) and then following the Quick Start instructions for a Vue app.

--- a/examples/editor-sdk-activation/readme.md
+++ b/examples/editor-sdk-activation/readme.md
@@ -2,10 +2,6 @@
 
 This demo shows the different options for the [Grammarly Text Editor SDK](https://developer.grammarly.com/) [activation property](https://developer.grammarly.com/docs/api/editor-sdk/editorconfig#activation).
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-activation?file=/public/index.html).
-
 ## How it works
 
 This example contains two files that are identical except for the value of the `activation` property:

--- a/examples/editor-sdk-angular/readme.md
+++ b/examples/editor-sdk-angular/readme.md
@@ -2,10 +2,6 @@
 
 This demo shows how to add the [Grammarly Text Editor SDK](https://developer.grammarly.com/) to a `<textarea>`, `<input>`, and elements with attribute `contenteditable="true"` in an Angular app.
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-angular).
-
 ## How it works
 
 [app.component.ts](./src/app/app.component.ts) finds the `<textarea>`, `<input>`, and `<div>` (that is `contenteditable`) that are in [app.component.html](./src/app/app.component.html) and then, for each element, invokes [addPlugin()](https://developer.grammarly.com/docs/api/editor-sdk/editorsdk#addplugin) to add Grammarly's writing suggestions in an imperative way.

--- a/examples/editor-sdk-autocomplete/readme.md
+++ b/examples/editor-sdk-autocomplete/readme.md
@@ -2,10 +2,6 @@
 
 This demo shows how to add [autocomplete](https://developer.grammarly.com/docs/api/editor-sdk/editorconfig#autocomplete) to  [Grammarly Text Editor SDK](https://developer.grammarly.com/).
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-autocomplete?file=/public/index.html).
-
 ## How it works
 
 [index.html](./public/index.html) contains `<input>`, `<textarea>` and `<div contenteditable>` elements. These elements are wrapped with the `<grammarly-editor-plugin>` tag so that Grammarly suggestions will be displayed in them. JavaScript code toward the bottom of the file configures the Grammarly Text Editor SDK. See [index.html](./public/index.html) for the full code example.

--- a/examples/editor-sdk-ckeditor-imperative/readme.md
+++ b/examples/editor-sdk-ckeditor-imperative/readme.md
@@ -2,10 +2,6 @@
 
 This demo shows how to add the [Grammarly Text Editor SDK](https://developer.grammarly.com/) to a [CKEditor](https://ckeditor.com/) rich text editor. The example uses [addPlugin()](https://developer.grammarly.com/docs/api/editor-sdk/editorsdk#addplugin) to add the Grammarly suggestions in an imperative way.
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-ckeditor-imperative?file=/public/index.html).
-
 ## How it works
 
 [index.html](./public/index.html) contains a `<div>`. JavaScript code toward the bottom of the file creates a new [classic editor](https://ckeditor.com/docs/ckeditor5/latest/api/module_editor-classic_classiceditor-ClassicEditor.html) instance in that `<div>` and also adds Grammarly suggestions to that `<div>`. See [index.html](./public/index.html) for the full code example.

--- a/examples/editor-sdk-ckeditor/readme.md
+++ b/examples/editor-sdk-ckeditor/readme.md
@@ -2,10 +2,6 @@
 
 This demo shows how to add the [Grammarly Text Editor SDK](https://developer.grammarly.com/) to a [CKEditor](https://ckeditor.com/) rich text editor.
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-ckeditor?file=/public/index.html).
-
 ## How it works
 
 [index.html](./public/index.html) contains a `<div>`. The `<div>` is wrapped with the `<grammarly-editor-plugin>` tag, so that Grammarly suggestions will be displayed in the `div`. JavaScript code toward the bottom of the file creates a new [classic editor](https://ckeditor.com/docs/ckeditor5/latest/api/module_editor-classic_classiceditor-ClassicEditor.html) instance in that `<div>` and also configures the Grammarly Text Editor SDK. See [index.html](./public/index.html) for the full code example.

--- a/examples/editor-sdk-document-dialect/readme.md
+++ b/examples/editor-sdk-document-dialect/readme.md
@@ -2,10 +2,6 @@
 
 This demo shows how to configure [documentDialect](https://developer.grammarly.com/docs/api/editor-sdk/editorconfig#documentdialect) for the [Grammarly Text Editor Plugin](https://developer.grammarly.com/).
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-document-dialect?file=/public/index.html).
-
 ## How it works
 
 [index.html](./public/index.html) and the other HTML files in this repository contain `<div contenteditable>` elements. These elements are wrapped with the `<grammarly-editor-plugin>` web component so that Grammarly suggestions display in the specified text areas. 

--- a/examples/editor-sdk-document-domain/readme.md
+++ b/examples/editor-sdk-document-domain/readme.md
@@ -2,10 +2,6 @@
 
 This demo shows how to configure the [documentDomain](https://developer.grammarly.com/docs/api/editor-sdk/editorconfig#documentdomain) for the [Grammarly Text Editor SDK](https://developer.grammarly.com/).
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-document-domain?file=/public/index.html).
-
 ## How it works
 
 [index.html](./public/index.html) and the other HTML files in this repository contain `div contenteditable` elements. We've added the Grammarly Text Editor Plugin to these elements by wrapping them with the `<grammarly-editor-plugin>` web component. The plugin displays Grammarly suggestions as users enter text. 

--- a/examples/editor-sdk-editorjs/readme.md
+++ b/examples/editor-sdk-editorjs/readme.md
@@ -2,33 +2,6 @@
 
 This demo shows how to add the [Grammarly Text Editor SDK](https://developer.grammarly.com/) to a [Editor.js](https://editorjs.io/) rich text editor. The example uses [addPlugin()](https://developer.grammarly.com/docs/api/editor-sdk/editorsdk#addplugin) to add Grammarly suggestions in an imperative way.
 
-## Try the demo online
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-editorjs?file=/public/index.html).
-
-## Try the demo locally
-You can try the demo locally using Vite. Navigate to the `editor-sdk-editorjs` directory and follow the steps below.
-
-### 1. Install the project's dependencies.
-
-With npm:\
-`npm install`
-
-With pnpm:\
-`pnpm install`
-
-### 2. Run the project.
-
-With npm:\
-`npm run dev`
-
-With pnpm:\
-`pnpm vite`
-
-### 3. Navigate the project.
-
-Once the project is running, you will see a message from Vite indicating where the project is running. By default, the project runs on localhost:5173. 
-
 ## How it works
 
 [index.html](./public/index.html) contains a `<div>`. JavaScript code toward the bottom of the file initializes the Editor.js text editor on that `<div>` and also adds Grammarly suggestions to that `<div>`. Check out [index.html](./public/index.html) for the full code example.

--- a/examples/editor-sdk-events/readme.md
+++ b/examples/editor-sdk-events/readme.md
@@ -2,10 +2,6 @@
 
 This demo shows how to add [event listeners](https://developer.grammarly.com/docs/api/editor-sdk/grammarlyeditorpluginelementeventmap#grammarlyeditorpluginelementeventmap) to  [Grammarly Text Editor SDK](https://developer.grammarly.com/).
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-events?file=/public/index.html).
-
 ## How it works
 
 [index.html](./public/index.html) contains `<div contenteditable>` elements. These elements are wrapped with the `<grammarly-editor-plugin>` tag so that Grammarly suggestions will be displayed in them. JavaScript code toward the bottom of the file adds event listeners to the plugin. See [index.html](./public/index.html) for the full code example.

--- a/examples/editor-sdk-intro-text/readme.md
+++ b/examples/editor-sdk-intro-text/readme.md
@@ -2,10 +2,6 @@
 
 This demo shows how to add [introText](https://developer.grammarly.com/docs/api/editor-sdk/editorconfig#introtext) to  [Grammarly Text Editor SDK](https://developer.grammarly.com/).
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-intro-text?file=/public/index.html).
-
 ## How it works
 
 [index.html](./public/index.html) contains `<div contenteditable>` elements. These elements are wrapped with the `<grammarly-editor-plugin>` tag so that Grammarly suggestions will be displayed in them. JavaScript code toward the bottom of the file configures the Grammarly Text Editor SDK. See [index.html](./public/index.html) for the full code example.

--- a/examples/editor-sdk-menu-position/readme.md
+++ b/examples/editor-sdk-menu-position/readme.md
@@ -2,10 +2,6 @@
 
 This demo shows how to set the [menu position](https://developer.grammarly.com/docs/api/editor-sdk/grammarlybuttonelement#menuposition) of the Grammarly button in the [Grammarly Text Editor SDK](https://developer.grammarly.com/).
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-menu-position?file=/public/index.html).
-
 ## How it works
 
 [index.html](./public/index.html) and the other HTML files in this repository explicitly add the `<grammarly-button>` element to the page. The element includes the `menu-position` attribute, setting it to either `left` or `right`.

--- a/examples/editor-sdk-quill-imperative/readme.md
+++ b/examples/editor-sdk-quill-imperative/readme.md
@@ -2,10 +2,6 @@
 
 This demo shows how to add the [Grammarly Text Editor SDK](https://developer.grammarly.com/) to a [Quill](https://quilljs.com/) rich text editor. The example uses [addPlugin()](https://developer.grammarly.com/docs/api/editor-sdk/editorsdk#addplugin) to add Grammarly suggestions in an imperative way.
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-quill-imperative?file=/public/index.html).
-
 ## How it works
 
 [index.html](./public/index.html) contains a `<div>`. JavaScript code toward the bottom of the file initializes the Quill text editor on that `<div>` and also adds Grammarly suggestions to that `<div>`. See [index.html](./public/index.html) for the full code example.

--- a/examples/editor-sdk-quill/readme.md
+++ b/examples/editor-sdk-quill/readme.md
@@ -2,10 +2,6 @@
 
 This demo shows how to add the [Grammarly Text Editor SDK](https://developer.grammarly.com/) to a [Quill](https://quilljs.com/) rich text editor.
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-quill?file=/public/index.html).
-
 ## How it works
 
 [index.html](./public/index.html) contains a `<div>`. The `<div>` is wrapped with the `<grammarly-editor-plugin>` tag, so that Grammarly suggestions will be displayed in the `div`. JavaScript code toward the bottom of the file initializes the Quill text editor on that `<div>` and also configures the Grammarly Text Editor SDK. See [index.html](./public/index.html) for the full code example.

--- a/examples/editor-sdk-react-ckeditor/readme.md
+++ b/examples/editor-sdk-react-ckeditor/readme.md
@@ -2,10 +2,6 @@
 
 This demo shows how to add the [Grammarly Text Editor SDK](https://developer.grammarly.com/) to a [CKEditor](https://ckeditor.com/) rich text editor in React.
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-react-ckeditor?file=/src/Editors.js).
-
 ## How it works
 
 The `<GrammarlyEditorPlugin>` component wraps a [classic editor](https://ckeditor.com/docs/ckeditor5/latest/api/module_editor-classic_classiceditor-ClassicEditor.html) in order to add Grammarly suggestions to it. The `<Grammarly>` component wraps the `<GrammarlyEditorPlugin>` component and configures the Grammarly Text Editor SDK. See [Editors.js](./src/Editors.js) for the full code example.

--- a/examples/editor-sdk-react-slate/readme.md
+++ b/examples/editor-sdk-react-slate/readme.md
@@ -2,10 +2,6 @@
 
 This demo shows how to add the [Grammarly Text Editor SDK](https://developer.grammarly.com/) to a [Slate](https://docs.slatejs.org/) rich text editor in React.
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-react-slate?file=/src/Editor.js).
-
 ## How it works
 
 The `<GrammarlyEditorPlugin>` component wraps a Slate rich text editor in order to add Grammarly suggestions to it.  The `<Grammarly>` component wraps the `<GrammarlyEditorPlugin>` component and configures the Grammarly Text Editor SDK. See [Editor.js](./src/Editor.js) for the full code example.

--- a/examples/editor-sdk-react-stats/readme.md
+++ b/examples/editor-sdk-react-stats/readme.md
@@ -7,10 +7,6 @@ This demo shows how to listen for and handle the `session-stats` and `document-s
 **Note**: The `session-stats` and `document-stats` events are only emitted for applications on the [Plus plan](https://developer.grammarly.com/plans). Check out the [Custom Events](https://developer.grammarly.com/docs/events#custom-events) documentation page for a full list of events.
 
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-react-stats?file=/src/Editor.js).
-
 ## How it works
 
 The `<GrammarlyEditorPlugin>` React component contains callback props for events that are emitted by the Text Editor Plugin. As an example, the [onSessionStats](https://developer.grammarly.com/docs/api/editor-sdk/grammarlyeditorplugincallbacks#onsessionstats) and [onDocumentStats](https://developer.grammarly.com/docs/api/editor-sdk/grammarlyeditorplugincallbacks#ondocumentstats) callbacks listen for and handle the `session-stats` and `document-stats` events. 

--- a/examples/editor-sdk-react-tinymce/readme.md
+++ b/examples/editor-sdk-react-tinymce/readme.md
@@ -2,10 +2,6 @@
 
 This demo shows how to add the [Grammarly Text Editor SDK](https://developer.grammarly.com/) to a [TinyMCE](https://www.tiny.cloud/) rich text editor in React.
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-react-tinymce?file=/src/Editors.js).
-
 ## How it works
 
 The `<GrammarlyEditorPlugin>` component wraps a TinyMCE rich text editor in order to add Grammarly suggestions to it. The `<Grammarly>` component wraps the `<GrammarlyEditorPlugin>` component and configures the Grammarly Text Editor SDK. See [Editors.js](./src/Editors.js) for the full code example.

--- a/examples/editor-sdk-react-turn-off-ui-elements/readme.md
+++ b/examples/editor-sdk-react-turn-off-ui-elements/readme.md
@@ -2,10 +2,6 @@
 
 This demo app shows three ways to turn off UI elements in the [Grammarly Text Editor SDK](https://developer.grammarly.com/) in React.
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-react-turn-off-ui-elements?file=/src/Editors.js).
-
 ## How it works
 
 The app contains a textarea with default text. The Grammarly Text Editor Plugin has been added to the textarea. The default experience will be turned on when the page loads.

--- a/examples/editor-sdk-react/readme.md
+++ b/examples/editor-sdk-react/readme.md
@@ -2,10 +2,6 @@
 
 This demo shows how to add the [Grammarly Text Editor SDK](https://developer.grammarly.com/) to a `<textarea>`, `<input>`, and elements with attribute `contenteditable="true"` in a React app. 
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-react).
-
 ## How it works
 
 [Editors.js](./src/Editors.js) contains a `<textarea>`, `<input>`, and `<div>` that is `contenteditable`, with each element wrapped with the `<GrammarlyEditorPlugin>` component. For rendering, [index.js](./src/index.js) specifies the Editors in [Editors.js](./src/Editors.js) that have text defined in [demo.js](./src/demo.js).

--- a/examples/editor-sdk-suggestions-config/readme.md
+++ b/examples/editor-sdk-suggestions-config/readme.md
@@ -2,10 +2,6 @@
 
 This demo shows how to turn on [categories of writing suggestions](https://developer.grammarly.com/docs/api/editor-sdk/editorconfig#suggestions) in the [Grammarly Text Editor SDK](https://developer.grammarly.com/).
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-suggestions-config?file=/public/index.html).
-
 ## How it works
 
 [index.html](./public/index.html) and the other HTML files in this repository contain `<div contenteditable>` elements. These elements are wrapped with the `<grammarly-editor-plugin>` web component so that Grammarly's writing suggestions are displayed within the `contenteditable` text areas. 

--- a/examples/editor-sdk-tinymce-imperative/readme.md
+++ b/examples/editor-sdk-tinymce-imperative/readme.md
@@ -2,10 +2,6 @@
 
 This demo shows how to add the [Grammarly Text Editor SDK](https://developer.grammarly.com/) to a [TinyMCE](https://www.tiny.cloud/) rich text editor. The example uses [addPlugin()](https://developer.grammarly.com/docs/api/editor-sdk/editorsdk#addplugin) to add the Grammarly suggestions in an imperative way.
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-tinymce-imperative?file=/public/index.html).
-
 ## How it works
 
 [index.html](./public/index.html) contains a `<textarea>` and a `<div>`. A JavaScript function toward the bottom of the file calls a function that adds Grammarly suggestions to the `<textarea>` and `<div>`. The function also initializes TinyMCE on those elements. See [index.html](./public/index.html) for the full code example.

--- a/examples/editor-sdk-tinymce/readme.md
+++ b/examples/editor-sdk-tinymce/readme.md
@@ -2,10 +2,6 @@
 
 This demo shows how to add the [Grammarly Text Editor SDK](https://developer.grammarly.com/) to a [TinyMCE](https://www.tiny.cloud/) rich text editor.
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-tinymce?file=/public/index.html).
-
 ## How it works
 
 [index.html](./public/index.html) contains a `<textarea>` and a `<div>`. The `<textarea>` and `<div>` are each wrapped with the `<grammarly-editor-plugin>` tag, so that Grammarly suggestions will be displayed in those elements. JavaScript code toward the bottom of the file initializes TinyMCE on those elements and also configures the Grammarly Text Editor SDK.  See [index.html](./public/index.html) for the full code example.

--- a/examples/editor-sdk-tone/readme.md
+++ b/examples/editor-sdk-tone/readme.md
@@ -2,10 +2,6 @@
 
 This demo shows how to add [Tone Detector](https://developer.grammarly.com/docs/api/editor-sdk/editorconfig#tonedetector) config to [Grammarly Text Editor SDK](https://developer.grammarly.com/).
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-tone?file=/public/index.html).
-
 ## How it works
 
 [index.html](./public/index.html) contains `<div contenteditable>` elements. These elements are wrapped with the `<grammarly-editor-plugin>` tag so that Grammarly suggestions will be displayed in them. JavaScript code toward the bottom of the file configures the Grammarly Text Editor SDK. See [index.html](./public/index.html) for the full code example.

--- a/examples/editor-sdk-turn-off-ui-elements/readme.md
+++ b/examples/editor-sdk-turn-off-ui-elements/readme.md
@@ -2,10 +2,6 @@
 
 This demo app shows three ways to turn off UI elements in the [Grammarly Text Editor SDK](https://developer.grammarly.com/).
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-turn-off-ui-elements?file=/public/index.html).
-
 ## How it works
 
 The app contains a textarea with default text. The Grammarly Text Editor Plugin has been added to the textarea. The default experience will be turned on when the page loads.

--- a/examples/editor-sdk-vue-ckeditor/readme.md
+++ b/examples/editor-sdk-vue-ckeditor/readme.md
@@ -2,10 +2,6 @@
 
 This demo shows how to add the [Grammarly Text Editor SDK](https://developer.grammarly.com/) to a [CKEditor](https://ckeditor.com/) rich text editor in Vue.
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-vue-ckeditor?file=/src/components/Editors.vue).
-
 ## How it works
 
 The `<GrammarlyEditorPlugin>` component wraps a [classic editor](https://ckeditor.com/docs/ckeditor5/latest/api/module_editor-classic_classiceditor-ClassicEditor.html) in order to add Grammarly suggestions to it. The `<Grammarly>` component wraps the `<GrammarlyEditorPlugin>` component and configures the Grammarly Text Editor SDK. See [Editors.js](./src/components/Editors.vue) for the full code example.

--- a/examples/editor-sdk-vue-tinymce/readme.md
+++ b/examples/editor-sdk-vue-tinymce/readme.md
@@ -2,10 +2,6 @@
 
 This demo shows how to add the [Grammarly Text Editor SDK](https://developer.grammarly.com/) to a [TinyMCE](https://www.tiny.cloud/) rich text editor in Vue.
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-vue-tinymce?file=/src/components/Editors.vue).
-
 ## How it works
 
 The `<GrammarlyEditorPlugin>` component wraps a TinyMCE rich text editor in order to add Grammarly suggestions to it. The `<Grammarly>` component wraps the `<GrammarlyEditorPlugin>` component and configures the Grammarly Text Editor SDK. See [Editors.js](./src/components/Editors.vue) for the full code example.

--- a/examples/editor-sdk-vue/readme.md
+++ b/examples/editor-sdk-vue/readme.md
@@ -2,10 +2,6 @@
 
 This demo shows how to add the [Grammarly Text Editor SDK](https://developer.grammarly.com/) to a `<textarea>`, `<input>`, and elements with attribute `contenteditable="true"` in a Vue app. 
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk-vue).
-
 ## How it works
 
 [Editors.vue](./src/components/Editors.vue) contains a `<textarea>`, `<input>`, and `<div>` that is `contenteditable`, with each element wrapped with the `<GrammarlyEditorPlugin>` component. For rendering, [App.vue](./src/App.vue) specifies the Editors in [Editors.vue](./src/components/Editors.vue) that have text defined in [demo.js](./src/components/demo.js).

--- a/examples/editor-sdk/readme.md
+++ b/examples/editor-sdk/readme.md
@@ -2,10 +2,6 @@
 
 This demo shows how to add the [Grammarly Text Editor SDK](https://developer.grammarly.com/) to a `<textarea>`, `<input>`, and `<div>` in a vanilla JavaScript app. 
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/editor-sdk?file=/public/index.html).
-
 ## How it works
 
 [index.html](./public/index.html) contains a `<textarea>`, `<input>`, and `<div>`. The example uses the [`data-grammarly` attribute](https://developer.grammarly.com/docs/editor-sdk-intro#usage) to add  Grammarly suggestions to the HTML elements. See [index.html](./public/index.html) for the full code example.

--- a/examples/trusted-auth/readme.md
+++ b/examples/trusted-auth/readme.md
@@ -2,10 +2,6 @@
 
 This demo shows how to configure the [Grammarly Text Editor SDK](https://developer.grammarly.com/) to use a custom function as a value for the `oauthAssertionProvider` attribute. The example uses a vanilla JavaScript app.
 
-## Try the demo
-
-You can try the demo in [CodeSandbox](https://codesandbox.io/s/github/grammarly/grammarly-for-developers/tree/main/examples/trusted-auth?file=/public/index.html).
-
 ## How it works
 
 [index.html](./public/index.html) contains a `<textarea>`. The example uses the [`oauthAssertionProvider` attribute](https://developer.grammarly.com/docs/editor-sdk-intro#usage) to provide trusted authentication assertions to the SDK.


### PR DESCRIPTION
In coordination with https://developer.grammarly.com/sdk-deprecation, remove links to CodeSandbox, as the Text Editor SDK will be discontinued on Wednesday, January 10, 2024.